### PR TITLE
fix: [CDS-76353]: fixed incorrect fqn of deployment templates variable

### DIFF
--- a/src/modules/75-cd/components/TemplateStudio/DeploymentTemplateCanvas/DeploymentTemplateForm/DeploymentInfraWrapper/__tests__/__snapshots__/DeploymentInfraWrapper.test.tsx.snap
+++ b/src/modules/75-cd/components/TemplateStudio/DeploymentTemplateCanvas/DeploymentTemplateForm/DeploymentInfraWrapper/__tests__/__snapshots__/DeploymentInfraWrapper.test.tsx.snap
@@ -1151,7 +1151,9 @@ exports[`Test DeploymentInfraWrapperWithRef initial render with data - inline sc
                             class="bp3-popover-target"
                           >
                             <button
-                              class="bp3-button Button--button StyledProps--font StyledProps--main btn Button--with-current-color Button--iconOnly Button--withLeftIcon"
+                              class="bp3-button bp3-disabled Button--button StyledProps--font StyledProps--main btn Button--with-current-color Button--iconOnly Button--withLeftIcon"
+                              disabled=""
+                              tabindex="-1"
                               type="button"
                             >
                               <span
@@ -1935,7 +1937,9 @@ exports[`Test DeploymentInfraWrapperWithRef should match inputs and labels for D
                             class="bp3-popover-target"
                           >
                             <button
-                              class="bp3-button Button--button StyledProps--font StyledProps--main btn Button--with-current-color Button--iconOnly Button--withLeftIcon"
+                              class="bp3-button bp3-disabled Button--button StyledProps--font StyledProps--main btn Button--with-current-color Button--iconOnly Button--withLeftIcon"
+                              disabled=""
+                              tabindex="-1"
                               type="button"
                             >
                               <span


### PR DESCRIPTION
### Summary

Root Cause -

- Previously, the infrastructure path was fixed and `fqn` was hardcoded in the UI - `stage.spec.infrastructure.output.variable.${variable?.name}` for **Deployment templates variable**, resulting in incorrect expression.

Solution -

- Extracted `fqn` for each variable from `yamlProperties` in the `metadataMap` returned by this API - `template/api/templates/v2/variables` (inside **useTemplateVariables** hook)


#### Screenshots


Before -

<img width="1792" alt="Screenshot 2023-08-08 at 1 28 42 AM" src="https://github.com/harness/harness-core-ui/assets/73639897/17ed2aa4-67ee-4bee-b4e2-cee1d2f06ea0">



After -

<img width="1792" alt="Screenshot 2023-08-08 at 1 27 30 AM" src="https://github.com/harness/harness-core-ui/assets/73639897/9e8dc474-b01b-4e37-acca-ab5eddfaa25c">


#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
