### PR TITLE
feat: [CDS-74142]: Added details for Trigger Poling status in Trigger Listing Page

### DIFF
--- a/src/modules/72-triggers/pages/triggers/TriggerLandingPage/TriggerLandingPage.tsx
+++ b/src/modules/72-triggers/pages/triggers/TriggerLandingPage/TriggerLandingPage.tsx
@@ -23,8 +23,12 @@ import { yamlStringify } from '@common/utils/YamlHelperMethods'
 import useIsNewGitSyncRemotePipeline from '@triggers/components/Triggers/useIsNewGitSyncRemotePipeline'
 import { TriggerBreadcrumbs } from '@triggers/pages/trigger-details/TriggerDetails'
 import { useIsTriggerCreatePermission } from '@triggers/components/Triggers/useIsTriggerCreatePermission'
-import { getEnabledStatusTriggerValues, getTriggerIcon } from '../utils/TriggersListUtils'
-import { clearNullUndefined, ResponseStatus, TriggerTypes } from '../utils/TriggersWizardPageUtils'
+import {
+  getEnabledStatusTriggerValues,
+  getTriggerIcon,
+  isTriggerActivityHistoryDisabled
+} from '../utils/TriggersListUtils'
+import { clearNullUndefined, ResponseStatus } from '../utils/TriggersWizardPageUtils'
 import css from './TriggerLandingPage.module.scss'
 
 const loadingHeaderHeight = 43
@@ -128,7 +132,7 @@ const TriggerLandingPage: React.FC = ({ children }) => {
     {
       label: getString('activityHistoryLabel'),
       to: routes.toTriggersActivityHistoryPage(routeParams),
-      disabled: triggerType !== TriggerTypes.SCHEDULE && triggerType !== TriggerTypes.WEBHOOK
+      disabled: isTriggerActivityHistoryDisabled(triggerType)
     }
   ]
 

--- a/src/modules/72-triggers/pages/triggers/__tests__/TriggersPage.test.tsx
+++ b/src/modules/72-triggers/pages/triggers/__tests__/TriggersPage.test.tsx
@@ -29,10 +29,11 @@ const mockDelete = jest.fn().mockReturnValue(Promise.resolve({ data: {}, status:
 const mockUpdateTrigger = jest.fn().mockReturnValue(Promise.resolve({ data: {}, status: {} }))
 const mockCopy = jest.fn()
 const mockGetTriggersFunction = jest.fn()
+const fetchTriggerList = jest.fn()
 jest.mock('services/pipeline-ng', () => ({
   useGetTriggerListForTarget: jest.fn(args => {
     mockGetTriggersFunction(args)
-    return GetTriggerListForTargetResponse
+    return { ...GetTriggerListForTargetResponse, refetch: fetchTriggerList }
   }),
   useGetTrigger: jest.fn(() => GetTriggerResponse),
   useDeleteTrigger: jest.fn().mockImplementation(() => ({ mutate: mockDelete })),
@@ -352,5 +353,13 @@ describe('TriggersPage Triggers tests', () => {
       fireEvent.click(getByTestId(getDeleteTestId(triggerIdentifier)))
       expect(confirmDelete).not.toBeCalled()
     })
+  })
+
+  test('Triggers List should update every minutes', async () => {
+    jest.useFakeTimers()
+    render(<WrapperComponent />)
+    jest.advanceTimersByTime(60 * 1000)
+
+    expect(fetchTriggerList).toHaveBeenCalled()
   })
 })

--- a/src/modules/72-triggers/pages/triggers/__tests__/__snapshots__/TriggersPage.test.tsx.snap
+++ b/src/modules/72-triggers/pages/triggers/__tests__/__snapshots__/TriggersPage.test.tsx.snap
@@ -1531,9 +1531,7 @@ exports[`TriggersPage Triggers tests Renders/snapshots Initial Render - New Trig
                       <span
                         class="StyledProps--font StyledProps--main StyledProps--inline"
                         tabindex="0"
-                      >
-                        
-                      </span>
+                      />
                     </span>
                   </span>
                 </div>
@@ -1733,9 +1731,7 @@ exports[`TriggersPage Triggers tests Renders/snapshots Initial Render - New Trig
                       <span
                         class="StyledProps--font StyledProps--main StyledProps--inline"
                         tabindex="0"
-                      >
-                        
-                      </span>
+                      />
                     </span>
                   </span>
                 </div>
@@ -1936,9 +1932,7 @@ exports[`TriggersPage Triggers tests Renders/snapshots Initial Render - New Trig
                       <span
                         class="StyledProps--font StyledProps--main StyledProps--inline"
                         tabindex="0"
-                      >
-                        
-                      </span>
+                      />
                     </span>
                   </span>
                 </div>
@@ -4903,9 +4897,7 @@ exports[`TriggersPage Triggers tests Renders/snapshots Initial Render - Shows Tr
                       <span
                         class="StyledProps--font StyledProps--main StyledProps--inline"
                         tabindex="0"
-                      >
-                        
-                      </span>
+                      />
                     </span>
                   </span>
                 </div>
@@ -5105,9 +5097,7 @@ exports[`TriggersPage Triggers tests Renders/snapshots Initial Render - Shows Tr
                       <span
                         class="StyledProps--font StyledProps--main StyledProps--inline"
                         tabindex="0"
-                      >
-                        
-                      </span>
+                      />
                     </span>
                   </span>
                 </div>
@@ -5308,9 +5298,7 @@ exports[`TriggersPage Triggers tests Renders/snapshots Initial Render - Shows Tr
                       <span
                         class="StyledProps--font StyledProps--main StyledProps--inline"
                         tabindex="0"
-                      >
-                        
-                      </span>
+                      />
                     </span>
                   </span>
                 </div>

--- a/src/modules/72-triggers/pages/triggers/utils/TriggersListUtils.ts
+++ b/src/modules/72-triggers/pages/triggers/utils/TriggersListUtils.ts
@@ -299,12 +299,6 @@ export const getEnabledStatusTriggerValues = ({
   }
 }
 
-export enum TriggerStatusEnum {
-  FAILED = 'FAILED',
-  UNKNOWN = 'UNKNOWN',
-  SUCCESS = 'SUCCESS'
-}
-
 const TriggerCategoryToLabelMap: Record<Required<TriggerCatalogItem>['category'], StringKeys> = {
   Webhook: 'execution.triggerType.WEBHOOK',
   Artifact: 'pipeline.artifactTriggerConfigPanel.artifact',
@@ -393,3 +387,6 @@ export const getTriggerCategoryDrawerMapFromTriggerCatalogItem = (
 
 export const getTriggerBaseType = (triggerType?: TriggerType): TriggerBaseType | undefined =>
   triggerType === 'MultiRegionArtifact' ? 'Artifact' : triggerType
+
+export const isTriggerActivityHistoryDisabled = (triggerType: TriggerType): boolean =>
+  triggerType !== 'Scheduled' && triggerType !== 'Webhook'

--- a/src/modules/72-triggers/pages/triggers/views/TriggersList.tsx
+++ b/src/modules/72-triggers/pages/triggers/views/TriggersList.tsx
@@ -41,6 +41,7 @@ import type {
   SourceRepo,
   TriggerBaseType
 } from '@triggers/components/Triggers/TriggerInterface'
+import { usePolling } from '@common/hooks/usePolling'
 import { TriggersListSection, GoToEditWizardInterface } from './TriggersListSection'
 import { TriggerTypes } from '../utils/TriggersWizardPageUtils'
 import { getCategoryItems, ItemInterface, TriggerDataInterface } from '../utils/TriggersListUtils'
@@ -92,6 +93,16 @@ export default function TriggersList(props: TriggersListPropsInterface & GitQuer
     },
     queryParamStringifyOptions: { arrayFormat: 'repeat' }
   })
+
+  usePolling(
+    () => {
+      fetchTriggerList()
+
+      return triggerListDataLoadingError ? Promise.reject() : Promise.resolve()
+    },
+    // Automatically refresh triggers list page  at every 1 minute
+    { startPolling: !triggerListDataLoadingError, pollingInterval: 60_000 }
+  )
 
   const triggerList = triggerListResponse?.data?.content || undefined
   const history = useHistory()

--- a/src/modules/72-triggers/pages/triggers/views/TriggersListSection.tsx
+++ b/src/modules/72-triggers/pages/triggers/views/TriggersListSection.tsx
@@ -269,8 +269,10 @@ const RenderColumnTrigger: Renderer<CellProps<NGTriggerDetailsResponse>> = ({
 }
 
 const RenderColumnStatus: Renderer<CellProps<NGTriggerDetailsResponse>> = ({ row }) => {
-  const { triggerStatus } = row.original
-  return triggerStatus ? <TriggerStatusCell triggerStatus={triggerStatus} /> : null
+  const { triggerStatus, identifier, type } = row.original
+  return triggerStatus ? (
+    <TriggerStatusCell triggerStatus={triggerStatus} triggerIdentifier={identifier} triggerType={type} />
+  ) : null
 }
 
 const RenderColumnActivity: Renderer<CellProps<NGTriggerDetailsResponse>> = ({

--- a/src/modules/72-triggers/pages/triggers/views/subviews/__tests__/TriggerStatus.test.tsx
+++ b/src/modules/72-triggers/pages/triggers/views/subviews/__tests__/TriggerStatus.test.tsx
@@ -5,18 +5,39 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import React from 'react'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import React, { ReactElement } from 'react'
+import { render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type { TriggerStatus } from 'services/pipeline-ng'
 import { TestWrapper } from '@common/utils/testUtils'
-import TriggerStatusCell from '../TriggerStatusCell'
+import TriggerStatusCell, { TriggerStatusProps } from '../TriggerStatusCell'
+
+const WrapperComponent = ({ triggerStatus, triggerIdentifier, triggerType }: TriggerStatusProps): ReactElement => {
+  return (
+    <TestWrapper
+      path="/account/:accountId/home/orgs/:orgIdentifier/projects/:projectIdentifier/pipelines/:pipelineIdentifier/triggers"
+      pathParams={{
+        accountId: 'default',
+        orgIdentifier: 'default',
+        projectIdentifier: 'test',
+        pipelineIdentifier: 'test-pipeline'
+      }}
+    >
+      <TriggerStatusCell
+        triggerStatus={triggerStatus}
+        triggerIdentifier={triggerIdentifier}
+        triggerType={triggerType}
+      />
+    </TestWrapper>
+  )
+}
 
 describe('Test case for trigger status rendering and behavior', () => {
   test('should render SUCCESS status properly', async () => {
     const triggerStatusMock: TriggerStatus = { status: 'SUCCESS', detailMessages: [] }
     const { getByText } = render(
       <TestWrapper>
-        <TriggerStatusCell triggerStatus={triggerStatusMock} />
+        <TriggerStatusCell triggerStatus={triggerStatusMock} triggerIdentifier="test-trigger" triggerType="Webhook" />
       </TestWrapper>
     )
 
@@ -27,7 +48,7 @@ describe('Test case for trigger status rendering and behavior', () => {
     const triggerStatusMock: TriggerStatus = { status: 'FAILED', detailMessages: [] }
     const { getByText } = render(
       <TestWrapper>
-        <TriggerStatusCell triggerStatus={triggerStatusMock} />
+        <TriggerStatusCell triggerStatus={triggerStatusMock} triggerIdentifier="test-trigger" triggerType="Webhook" />
       </TestWrapper>
     )
 
@@ -38,7 +59,7 @@ describe('Test case for trigger status rendering and behavior', () => {
     const triggerStatusMock: TriggerStatus = { status: 'UNKNOWN', detailMessages: [] }
     const { getByText } = render(
       <TestWrapper>
-        <TriggerStatusCell triggerStatus={triggerStatusMock} />
+        <TriggerStatusCell triggerStatus={triggerStatusMock} triggerIdentifier="test-trigger" triggerType="Webhook" />
       </TestWrapper>
     )
 
@@ -49,7 +70,7 @@ describe('Test case for trigger status rendering and behavior', () => {
     const triggerStatusMock: TriggerStatus = {}
     const { container } = render(
       <TestWrapper>
-        <TriggerStatusCell triggerStatus={triggerStatusMock} />
+        <TriggerStatusCell triggerStatus={triggerStatusMock} triggerIdentifier="test-trigger" triggerType="Webhook" />
       </TestWrapper>
     )
 
@@ -60,11 +81,11 @@ describe('Test case for trigger status rendering and behavior', () => {
     const triggerStatusMock: TriggerStatus = { status: 'FAILED' }
     const { findByText, getByText } = render(
       <TestWrapper>
-        <TriggerStatusCell triggerStatus={triggerStatusMock} />
+        <TriggerStatusCell triggerStatus={triggerStatusMock} triggerIdentifier="test-trigger" triggerType="Webhook" />
       </TestWrapper>
     )
 
-    fireEvent.mouseEnter(getByText('failed'))
+    userEvent.hover(getByText('failed'))
     expect(await findByText('common.viewErrorDetails')).toBeDefined()
   })
 
@@ -72,32 +93,32 @@ describe('Test case for trigger status rendering and behavior', () => {
     const triggerStatusMock: TriggerStatus = { status: 'FAILED', detailMessages: ['error 1'] }
     const { getByText, findByText } = render(
       <TestWrapper>
-        <TriggerStatusCell triggerStatus={triggerStatusMock} />
+        <TriggerStatusCell triggerStatus={triggerStatusMock} triggerIdentifier="test-trigger" triggerType="Webhook" />
       </TestWrapper>
     )
 
-    fireEvent.mouseEnter(getByText('failed'))
+    userEvent.hover(getByText('failed'))
 
     expect(await findByText('error 1')).toBeDefined()
     expect(await findByText('common.viewErrorDetails')).toBeDefined()
   })
 
-  test('shoud open (and close) modal with error messages', async () => {
+  test('should open (and close) modal with error messages', async () => {
     const detailMessages = ['error 1', 'error 2']
     const triggerStatusMock: TriggerStatus = { status: 'FAILED', detailMessages }
     const { getByText, findByText, findByRole, findByTestId, queryByTestId, baseElement } = render(
       <TestWrapper>
-        <TriggerStatusCell triggerStatus={triggerStatusMock} />
+        <TriggerStatusCell triggerStatus={triggerStatusMock} triggerIdentifier="test-trigger" triggerType="Webhook" />
       </TestWrapper>
     )
 
     // open tooltip
-    fireEvent.mouseEnter(getByText('failed'))
+    userEvent.hover(getByText('failed'))
 
     // open modal
     const btn = await findByRole('button')
     expect(btn).toBeDefined()
-    fireEvent.click(btn)
+    userEvent.click(btn)
 
     const title = await findByText('errorDetails')
     expect(title).toBeDefined()
@@ -109,8 +130,108 @@ describe('Test case for trigger status rendering and behavior', () => {
 
     // close modal
     const closeBtn = baseElement.querySelector('button[aria-label="Close"]')
-    fireEvent.click(closeBtn!)
+    userEvent.click(closeBtn!)
 
     await waitFor(() => expect(queryByTestId('modaldialog-body')).toBeNull())
+  })
+
+  test('Should show last collected tags and time for SUCCESS artifact', async () => {
+    const lastPolled = 'ecrtriggerstatus-3'
+    const triggerStatusMock: TriggerStatus = {
+      status: 'SUCCESS',
+      detailMessages: [],
+      lastPollingUpdate: 1690339427992,
+      lastPolled: [lastPolled]
+    }
+    const { getByText, findByText } = render(
+      <WrapperComponent triggerStatus={triggerStatusMock} triggerIdentifier="test-trigger" triggerType="Artifact" />
+    )
+
+    userEvent.hover(getByText('success'))
+
+    await findByText('triggers.tagLastCollectedAt')
+
+    expect(getByText(new Date(triggerStatusMock.lastPollingUpdate!).toLocaleString())).toBeInTheDocument()
+
+    expect(getByText('triggers.lastCollectedTag')).toBeInTheDocument()
+    expect(getByText(lastPolled)).toBeInTheDocument()
+
+    // TODO: Uncomment this once we allow activity history page for Artifact & Manifest
+    /*  expect(getByText('activityHistoryLabel')).toHaveAttribute(
+      'href',
+      '/account/default/home/orgs/default/projects/test/pipelines/test-pipeline/triggers/test-trigger/activity-history'
+      ) */
+    // TODO: Remove this once we allow activity history page for Artifact & Manifest
+    expect(getByText('activityHistoryLabel').parentElement).toBeDisabled()
+  })
+
+  test('Should show last collected tags and time for SUCCESS manifest', async () => {
+    const lastPolled = 'ecrtriggerstatus-3'
+    const triggerStatusMock: TriggerStatus = {
+      status: 'SUCCESS',
+      detailMessages: [],
+      lastPollingUpdate: 1690339427992,
+      lastPolled: [lastPolled]
+    }
+    const { getByText, findByText } = render(
+      <WrapperComponent triggerStatus={triggerStatusMock} triggerIdentifier="test-trigger" triggerType="Manifest" />
+    )
+
+    userEvent.hover(getByText('success'))
+
+    await findByText('triggers.versionLastCollectedAt')
+
+    expect(getByText(new Date(triggerStatusMock.lastPollingUpdate!).toLocaleString())).toBeInTheDocument()
+
+    expect(getByText('triggers.lastCollectedVersion')).toBeInTheDocument()
+    expect(getByText(lastPolled)).toBeInTheDocument()
+    // TODO: Uncomment this once we allow activity history page for Artifact & Manifest
+    /* expect(getByText('activityHistoryLabel')).toHaveAttribute(
+      'href',
+      '/account/default/home/orgs/default/projects/test/pipelines/test-pipeline/triggers/test-trigger/activity-history'
+    ) */
+    // TODO: Remove this once we allow activity history page for Artifact & Manifest
+    expect(getByText('activityHistoryLabel').parentElement).toBeDisabled()
+  })
+  test('Should show pending message for PENDING artifact', async () => {
+    const triggerStatusMock: TriggerStatus = {
+      status: 'PENDING'
+    }
+    const { getByText, findByText } = render(
+      <WrapperComponent triggerStatus={triggerStatusMock} triggerIdentifier="test-trigger" triggerType="Artifact" />
+    )
+
+    userEvent.hover(getByText('triggers.pending'))
+
+    await findByText('triggers.waitingForTag')
+
+    // TODO: Uncomment this once we allow activity history page for Artifact & Manifest
+    /* expect(getByText('activityHistoryLabel')).toHaveAttribute(
+      'href',
+      '/account/default/home/orgs/default/projects/test/pipelines/test-pipeline/triggers/test-trigger/activity-history'
+    ) */
+    // TODO: Remove this once we allow activity history page for Artifact & Manifest
+    expect(getByText('activityHistoryLabel').parentElement).toBeDisabled()
+  })
+
+  test('Should show pending message for PENDING  manifest', async () => {
+    const triggerStatusMock: TriggerStatus = {
+      status: 'PENDING'
+    }
+    const { getByText, findByText } = render(
+      <WrapperComponent triggerStatus={triggerStatusMock} triggerIdentifier="test-trigger" triggerType="Manifest" />
+    )
+
+    userEvent.hover(getByText('triggers.pending'))
+
+    await findByText('triggers.waitingForVersion')
+
+    // TODO: Uncomment this once we allow activity history page for Artifact & Manifest
+    /* expect(getByText('activityHistoryLabel')).toHaveAttribute(
+      'href',
+      '/account/default/home/orgs/default/projects/test/pipelines/test-pipeline/triggers/test-trigger/activity-history'
+    ) */
+    // TODO: Remove this once we allow activity history page for Artifact & Manifest
+    expect(getByText('activityHistoryLabel').parentElement).toBeDisabled()
   })
 })

--- a/src/modules/72-triggers/pages/triggers/views/subviews/__tests__/__snapshots__/TriggerStatus.test.tsx.snap
+++ b/src/modules/72-triggers/pages/triggers/views/subviews/__tests__/__snapshots__/TriggerStatus.test.tsx.snap
@@ -12,9 +12,7 @@ exports[`Test case for trigger status rendering and behavior should render witho
         <span
           class="StyledProps--font StyledProps--main StyledProps--inline"
           tabindex="0"
-        >
-          
-        </span>
+        />
       </span>
     </span>
   </div>

--- a/src/modules/72-triggers/strings/strings.en.yaml
+++ b/src/modules/72-triggers/strings/strings.en.yaml
@@ -8,6 +8,13 @@ newTriggerWithoutPlus: New Trigger
 pipelineExecutionInput: Pipeline Execution Input
 lastActivationDetails: Last Activation Details
 lastActivationAt: 'Last activation at'
+pending: Pending
+tagLastCollectedAt: Tag(s) last collected at
+versionLastCollectedAt: Version(s) last collected at
+lastCollectedTag: Last collected tag(s)
+lastCollectedVersion: Last collected version(s)
+waitingForTag: Waiting for first collection of tag(s)
+waitingForVersion: Waiting for first collection of version(s)
 showAllTriggers: 'Show All Triggers'
 onNewWebhookTitle: 'On New Webhook'
 onNewArtifactTitleWhole: 'On New Artifact'

--- a/src/stringTypes.ts
+++ b/src/stringTypes.ts
@@ -5633,6 +5633,8 @@ export interface StringsMap {
   'triggers.lastActivationAt': string
   'triggers.lastActivationDetails': string
   'triggers.lastActivationLabel': string
+  'triggers.lastCollectedTag': string
+  'triggers.lastCollectedVersion': string
   'triggers.newArtifactLabel': string
   'triggers.newManifestLabel': string
   'triggers.newTrigger': string
@@ -5645,6 +5647,7 @@ export interface StringsMap {
   'triggers.onNewWebhookTitle': string
   'triggers.onScheduleLabel': string
   'triggers.pageNotFound': string
+  'triggers.pending': string
   'triggers.pipelineExecutionInput': string
   'triggers.pipelineInputLabel': string
   'triggers.pipelineReferenceBranch': string
@@ -5685,6 +5688,7 @@ export interface StringsMap {
   'triggers.scheduledLabel': string
   'triggers.selectPipelineStages': string
   'triggers.showAllTriggers': string
+  'triggers.tagLastCollectedAt': string
   'triggers.toast.existingTriggerError': string
   'triggers.toast.payloadInfoBar': string
   'triggers.toast.successfulCreate': string
@@ -5746,6 +5750,9 @@ export interface StringsMap {
   'triggers.validation.repositoryFormat': string
   'triggers.validation.selectedArtifact': string
   'triggers.validation.triggerName': string
+  'triggers.versionLastCollectedAt': string
+  'triggers.waitingForTag': string
+  'triggers.waitingForVersion': string
   'discovery.agentName': string
   'discovery.allDiscoveredServices': string
   'discovery.approxTime': string


### PR DESCRIPTION
### Summary
→ For artifact/manifest triggers, on hovering on the trigger status, we need to show a popup window containing:

1. If the status is SUCCESS, the last collected tags (List<String> triggerStatus.lastPolled ) and the timestamp of the last collection (Long triggerStatus.lastPollingUpdate).

     Link to the Trigger activity page on hover to view the complete set of Trigger activity pages.
2. If the status is FAILED, the error message (we already show it today) and timestamp (Long triggerStatus.lastPollingUpdate).

    On hover link to the Trigger activity page along with the error message

3. If PENDING, an explanation message is as follows “Waiting for the first collection of tags/versions". (This status is Pending from BE as of now)

   On hover link to the Trigger activity page.

We also want to make the triggers list page automatically refresh at every 1 minute, in order for the trigger’s status to be updated accordingly.

Test Cases added:

- Refresh triggers list every 1 min.
- Show the last collected tags and time for SUCCESS artifact
- Show the last collected version and time for SUCCESS manifest
- Show pending message for PENDING artifact
- Show pending message for PENDING manifest

<!-- ✍️ A clear and concise description...-->

#### Screenshots
![Screenshot 2023-07-26 at 3 43 58 PM](https://github.com/harness/harness-core-ui/assets/110591046/8908c24c-bb7a-405c-a33b-b8c1bbbd321d)
<img width="788" alt="Screenshot 2023-07-26 at 5 49 23 PM" src="https://github.com/harness/harness-core-ui/assets/110591046/e8d4309e-89cd-4ea9-8da0-59b823b0422f">
<img width="750" alt="Screenshot 2023-07-26 at 5 51 56 PM" src="https://github.com/harness/harness-core-ui/assets/110591046/352c098b-1b18-493b-bad2-833a55a80a20">

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
