### PR TITLE
fix: [CDS-74504]: added merge-input-for-execution Api to handle inputset view at Execution page

### DIFF
--- a/src/modules/70-pipeline/components/RunPipelineModal/__tests__/RunPipelineForm.test.tsx
+++ b/src/modules/70-pipeline/components/RunPipelineModal/__tests__/RunPipelineForm.test.tsx
@@ -156,6 +156,7 @@ jest.mock('services/pipeline-ng', () => ({
   // used within useInputSets
   useGetTemplateFromPipeline: jest.fn(() => getMockFor_useGetTemplateFromPipeline()),
   useGetMergeInputSetFromPipelineTemplateWithListInput: jest.fn(() => getMockFor_Generic_useMutate(mockMergeInputSet)),
+  useGetMergeInputForExecution: jest.fn(() => getMockFor_Generic_useMutate(mockMergeInputSet)),
 
   // used within PipelineVaribalesContext
   useCreateVariablesV2: jest.fn(() => ({})),

--- a/src/modules/70-pipeline/components/RunPipelineModal/__tests__/useInputSets.test.tsx
+++ b/src/modules/70-pipeline/components/RunPipelineModal/__tests__/useInputSets.test.tsx
@@ -15,7 +15,8 @@ import { useInputSets } from '../useInputSets'
 import type { UseInputSetsProps } from '../useInputSets'
 jest.mock('services/pipeline-ng', () => ({
   useGetTemplateFromPipeline: jest.fn(() => ({})),
-  useGetMergeInputSetFromPipelineTemplateWithListInput: jest.fn(() => ({}))
+  useGetMergeInputSetFromPipelineTemplateWithListInput: jest.fn(() => ({})),
+  useGetMergeInputForExecution: jest.fn(() => ({}))
 }))
 
 const getInitialProps = (): UseInputSetsProps => ({

--- a/src/modules/70-pipeline/components/RunPipelineModal/__tests__/useRunPipelineModal.test.tsx
+++ b/src/modules/70-pipeline/components/RunPipelineModal/__tests__/useRunPipelineModal.test.tsx
@@ -61,6 +61,7 @@ jest.mock('services/pipeline-ng', () => ({
   useRePostPipelineExecuteWithInputSetYaml: jest.fn(() => getMockFor_Generic_useMutate()),
   useRerunStagesWithRuntimeInputYaml: jest.fn(() => getMockFor_Generic_useMutate()),
   useGetMergeInputSetFromPipelineTemplateWithListInput: jest.fn(() => getMockFor_Generic_useMutate()),
+  useGetMergeInputForExecution: jest.fn(() => getMockFor_Generic_useMutate()),
   useGetInputSetsListForPipeline: jest.fn(() => ({ data: null, refetch: jest.fn() })),
   useCreateVariablesV2: jest.fn(() => ({})),
   useCreateInputSetForPipeline: jest.fn(() => getMockFor_Generic_useMutate()),

--- a/src/modules/70-pipeline/pages/execution/ExecutionInputsView/ExecutionInputsView.tsx
+++ b/src/modules/70-pipeline/pages/execution/ExecutionInputsView/ExecutionInputsView.tsx
@@ -92,6 +92,7 @@ export default function ExecutionInputsView(props: ExecutionInputsViewInterface)
         executionInputSetTemplateYamlError={error}
         storeType={pipelineExecutionDetail?.pipelineExecutionSummary?.storeType as StoreType}
         storeMetadata={storeMetadata}
+        executionIdentifier={executionIdentifier}
       />
     </div>
   )

--- a/src/modules/70-pipeline/pages/execution/ExecutionInputsView/__tests__/ExecutionInputsView.test.tsx
+++ b/src/modules/70-pipeline/pages/execution/ExecutionInputsView/__tests__/ExecutionInputsView.test.tsx
@@ -36,6 +36,9 @@ jest.mock('services/pipeline-ng', () => ({
   useGetMergeInputSetFromPipelineTemplateWithListInput: jest.fn(() => ({
     mutate: jest.fn().mockResolvedValue({ data: {} })
   })),
+  useGetMergeInputForExecution: jest.fn(() => ({
+    mutate: jest.fn().mockResolvedValue({ data: {} })
+  })),
   useGetInputSetsListForPipeline: jest.fn(() => ({ data: null, refetch: jest.fn() })),
   useGetYamlSchema: jest.fn(() => ({ data: null })),
   useCreateInputSetForPipeline: jest.fn(() => ({ data: null })),

--- a/src/services/pipeline-ng/index.tsx
+++ b/src/services/pipeline-ng/index.tsx
@@ -8824,6 +8824,68 @@ export const getMergeInputSetForRunPromise = (
     void
   >('POST', getConfig('pipeline/api'), `/inputSets/merge-for-rerun`, props, signal)
 
+export interface GetMergeInputForExecutionQueryParams {
+  accountIdentifier: string
+  orgIdentifier: string
+  projectIdentifier: string
+  resolveExpressions?: boolean
+  resolveExpressionsType?: 'RESOLVE_ALL_EXPRESSIONS' | 'RESOLVE_TRIGGER_EXPRESSIONS' | 'UNKNOWN'
+  planExecutionId: string
+}
+
+export type GetMergeInputForExecutionProps = Omit<
+  MutateProps<ResponseMergeInputSetResponse, Failure | Error, GetMergeInputForExecutionQueryParams, void, void>,
+  'path' | 'verb'
+>
+
+/**
+ * Merges pipeline template and input set yaml of pipeline execution for given planExecutionId
+ */
+export const GetMergeInputForExecution = (props: GetMergeInputForExecutionProps) => (
+  <Mutate<ResponseMergeInputSetResponse, Failure | Error, GetMergeInputForExecutionQueryParams, void, void>
+    verb="POST"
+    path={`/inputSets/merge-input-for-execution`}
+    base={getConfig('pipeline/api')}
+    {...props}
+  />
+)
+
+export type UseGetMergeInputForExecutionProps = Omit<
+  UseMutateProps<ResponseMergeInputSetResponse, Failure | Error, GetMergeInputForExecutionQueryParams, void, void>,
+  'path' | 'verb'
+>
+
+/**
+ * Merges pipeline template and input set yaml of pipeline execution for given planExecutionId
+ */
+export const useGetMergeInputForExecution = (props: UseGetMergeInputForExecutionProps) =>
+  useMutate<ResponseMergeInputSetResponse, Failure | Error, GetMergeInputForExecutionQueryParams, void, void>(
+    'POST',
+    `/inputSets/merge-input-for-execution`,
+    { base: getConfig('pipeline/api'), ...props }
+  )
+
+/**
+ * Merges pipeline template and input set yaml of pipeline execution for given planExecutionId
+ */
+export const getMergeInputForExecutionPromise = (
+  props: MutateUsingFetchProps<
+    ResponseMergeInputSetResponse,
+    Failure | Error,
+    GetMergeInputForExecutionQueryParams,
+    void,
+    void
+  >,
+  signal?: RequestInit['signal']
+) =>
+  mutateUsingFetch<ResponseMergeInputSetResponse, Failure | Error, GetMergeInputForExecutionQueryParams, void, void>(
+    'POST',
+    getConfig('pipeline/api'),
+    `/inputSets/merge-input-for-execution`,
+    props,
+    signal
+  )
+
 export interface GetMergeInputSetFromPipelineTemplateQueryParams {
   accountIdentifier: string
   orgIdentifier: string


### PR DESCRIPTION
### Summary

Issue -> Input fields are empty for fields (in Input set view tab) whereas in the compiled Yaml we can see them

Fix: 

Here earlier we are using `inputsetV2` call for entering/override user entered values (at runtime form), but this alone is not sufficient for entering values for some cases such as in case user Yaml is truncated such as variables don't have types fields. So, for those cases we have a logic of using `merge` api calls but the exisiting `merge` call does not take `executionIdentifier` in account and hence if the pipeline yaml is changed then it always refer to the latest which breaks this past executions input yamls

Hence, added `/inputSets/merge-input-for-execution` for this.

#### Screenshots

Before:


https://github.com/harness/harness-core-ui/assets/98325173/e5ac26f8-e1d2-43df-aa45-5df4bdb95c50


After:

https://github.com/harness/harness-core-ui/assets/98325173/05b3a291-8a77-4656-8a4b-2195e2615c25



#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
