### PR TITLE
fix: [OIP-752]: Switch verification tabs by default based on the health source configuration

### DIFF
--- a/cypress/integration/85-cv/verifyStep/logsScreen.spec.ts
+++ b/cypress/integration/85-cv/verifyStep/logsScreen.spec.ts
@@ -17,6 +17,7 @@ import {
   healthSourceAPI,
   healthSourceMetricsAPI,
   healthSourcesResponse,
+  healthSourcesResponseWithLogs,
   jiraCreatePayload,
   jiraCreatePostCall,
   jiraIssueTypeMock,
@@ -151,6 +152,8 @@ describe('Verify step', () => {
       'logsRadarChartDataNodeFilterCall'
     )
 
+    cy.intercept('GET', healthSourceMetricsAPI, healthSourcesResponseWithLogs).as('healthSource')
+
     cy.intercept('GET', logsListCLusterFilterCall, logsListCallResponse).as('logsListCLusterFilterCall')
     cy.intercept('GET', logsRadarChartDataCLusterFilterCall, logsRadarChartDataCallResponse).as(
       'logsRadarChartDataCLusterFilterCall'
@@ -266,7 +269,12 @@ describe('Verify step', () => {
     // clicking again to go to verify step page
     cy.get('.bp3-switch').click()
 
-    cy.findByText(/^Logs/i).click({ force: true })
+    cy.wait('@healthSource')
+
+    cy.get('div[data-tab-id="Logs"][aria-disabled="false"]')
+      .should('be.visible')
+      .scrollIntoView()
+      .click({ force: true })
 
     cy.wait('@nodeNames')
 

--- a/cypress/support/85-cv/verifyStep/constants.ts
+++ b/cypress/support/85-cv/verifyStep/constants.ts
@@ -2693,3 +2693,12 @@ export const healthSourcesResponse = [
     providerType: 'METRICS'
   }
 ]
+
+export const healthSourcesResponseWithLogs = [
+  {
+    identifier: 'svc1_env1/slm',
+    name: 'sl-m2',
+    type: 'SumologicLogs',
+    providerType: 'LOGS'
+  }
+]

--- a/src/modules/85-cv/components/ExecutionVerification/ExecutionVerificationView.constants.ts
+++ b/src/modules/85-cv/components/ExecutionVerification/ExecutionVerificationView.constants.ts
@@ -1,0 +1,2 @@
+export const MetricsProviderType = 'METRICS'
+export const LogsProviderType = 'LOGS'

--- a/src/modules/85-cv/components/ExecutionVerification/ExecutionVerificationView.constants.ts
+++ b/src/modules/85-cv/components/ExecutionVerification/ExecutionVerificationView.constants.ts
@@ -1,2 +1,4 @@
 export const MetricsProviderType = 'METRICS'
 export const LogsProviderType = 'LOGS'
+
+export const LogsQueryParamName = 'Logs'

--- a/src/modules/85-cv/components/ExecutionVerification/ExecutionVerificationView.tsx
+++ b/src/modules/85-cv/components/ExecutionVerification/ExecutionVerificationView.tsx
@@ -72,11 +72,6 @@ export function ExecutionVerificationView(props: ExecutionVerificationViewProps)
   const canEnableMetricsTab = getCanEnableMetricsTab(healthSourcesData)
   const canEnableLogsTab = getCanEnableLogsTab(healthSourcesData)
 
-  // const defaultTabId = useMemo(
-  //   () => getDefaultTabId({ getString, tabName: type, canEnableMetricsTab, canEnableLogsTab }),
-  //   [canEnableLogsTab, canEnableMetricsTab, getString, type, healthSourcesLoading]
-  // )
-
   const [selectedTab, setSelectedTab] = useState(() =>
     getDefaultTabId({ getString, tabName: type, canEnableMetricsTab, canEnableLogsTab })
   )

--- a/src/modules/85-cv/components/ExecutionVerification/ExecutionVerificationView.tsx
+++ b/src/modules/85-cv/components/ExecutionVerification/ExecutionVerificationView.tsx
@@ -23,15 +23,10 @@ import {
 import { DeploymentMetrics } from './components/DeploymentMetrics/DeploymentMetrics'
 import { ExecutionVerificationSummary } from './components/ExecutionVerificationSummary/ExecutionVerificationSummary'
 import LogAnalysisContainer from './components/LogAnalysisContainer/LogAnalysisView.container'
-import {
-  getActivityId,
-  getCanEnableLogsTab,
-  getCanEnableMetricsTab,
-  getDefaultTabId
-} from './ExecutionVerificationView.utils'
+import { getActivityId, getCanEnableTabByType, getDefaultTabId } from './ExecutionVerificationView.utils'
 import { ManualInterventionVerifyStep } from './components/ManualInterventionVerifyStep/ManualInterventionVerifyStep'
 import InterruptedHistory from './components/InterruptedHistory/InterruptedHistory'
-import { LogsQueryParamName } from './ExecutionVerificationView.constants'
+import { LogsProviderType, LogsQueryParamName, MetricsProviderType } from './ExecutionVerificationView.constants'
 import css from './ExecutionVerificationView.module.scss'
 
 interface ExecutionVerificationViewProps {
@@ -70,8 +65,8 @@ export function ExecutionVerificationView(props: ExecutionVerificationViewProps)
     lazy: type !== LogsQueryParamName
   })
 
-  const canEnableMetricsTab = getCanEnableMetricsTab(healthSourcesData)
-  const canEnableLogsTab = getCanEnableLogsTab(healthSourcesData)
+  const canEnableMetricsTab = getCanEnableTabByType(healthSourcesData, MetricsProviderType)
+  const canEnableLogsTab = getCanEnableTabByType(healthSourcesData, LogsProviderType)
 
   const [selectedTab, setSelectedTab] = useState(() =>
     getDefaultTabId({ getString, tabName: type, canEnableMetricsTab, canEnableLogsTab })
@@ -79,7 +74,7 @@ export function ExecutionVerificationView(props: ExecutionVerificationViewProps)
 
   useEffect(() => {
     setSelectedTab(getDefaultTabId({ getString, tabName: type, canEnableMetricsTab, canEnableLogsTab }))
-  }, [canEnableLogsTab, canEnableMetricsTab, getString, type])
+  }, [canEnableLogsTab, canEnableMetricsTab, type])
 
   const handleTabChange = useCallback(nextTabId => {
     setSelectedNode(undefined)
@@ -114,10 +109,12 @@ export function ExecutionVerificationView(props: ExecutionVerificationViewProps)
                 activityId={activityId}
                 overviewData={data}
                 overviewLoading={loading}
-                healthSourcesData={healthSourcesData}
-                healthSourcesError={healthSourcesError}
-                healthSourcesLoading={healthSourcesLoading}
-                fetchHealthSources={fetchHealthSources}
+                healthSourceDetails={{
+                  healthSourcesData,
+                  healthSourcesError,
+                  healthSourcesLoading,
+                  fetchHealthSources
+                }}
               />
             </Layout.Horizontal>
           }

--- a/src/modules/85-cv/components/ExecutionVerification/ExecutionVerificationView.tsx
+++ b/src/modules/85-cv/components/ExecutionVerification/ExecutionVerificationView.tsx
@@ -5,7 +5,7 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import React, { useMemo, useState, useCallback } from 'react'
+import React, { useMemo, useState, useCallback, useEffect } from 'react'
 import { useParams } from 'react-router-dom'
 import { Container, Tabs, Tab, NoDataCard, Layout, FlexExpander, Button, ButtonVariation } from '@harness/uicore'
 import { Color } from '@harness/design-system'
@@ -15,11 +15,20 @@ import type { ExecutionNode } from 'services/pipeline-ng'
 import { useLogContentHook } from '@cv/hooks/useLogContentHook/useLogContentHook'
 import type { ProjectPathProps } from '@common/interfaces/RouteInterfaces'
 import { LogTypes } from '@cv/hooks/useLogContentHook/useLogContentHook.types'
-import { AnalysedDeploymentNode, useGetVerificationOverviewForVerifyStepExecutionId } from 'services/cv'
+import {
+  AnalysedDeploymentNode,
+  useGetVerificationOverviewForVerifyStepExecutionId,
+  useGetHealthSourcesForVerifyStepExecutionId
+} from 'services/cv'
 import { DeploymentMetrics } from './components/DeploymentMetrics/DeploymentMetrics'
 import { ExecutionVerificationSummary } from './components/ExecutionVerificationSummary/ExecutionVerificationSummary'
 import LogAnalysisContainer from './components/LogAnalysisContainer/LogAnalysisView.container'
-import { getActivityId, getDefaultTabId } from './ExecutionVerificationView.utils'
+import {
+  getActivityId,
+  getCanEnableLogsTab,
+  getCanEnableMetricsTab,
+  getDefaultTabId
+} from './ExecutionVerificationView.utils'
 import { ManualInterventionVerifyStep } from './components/ManualInterventionVerifyStep/ManualInterventionVerifyStep'
 import InterruptedHistory from './components/InterruptedHistory/InterruptedHistory'
 import css from './ExecutionVerificationView.module.scss'
@@ -34,13 +43,8 @@ export function ExecutionVerificationView(props: ExecutionVerificationViewProps)
   const [selectedNode, setSelectedNode] = useState<AnalysedDeploymentNode | undefined>()
   const activityId = useMemo(() => getActivityId(step), [step])
   const { type } = useQueryParams<{ type?: string }>()
-  const defaultTabId = useMemo(() => getDefaultTabId(getString, type), [type])
 
   const { openLogContentHook } = useLogContentHook({ verifyStepExecutionId: activityId })
-
-  const handleTabChange = useCallback(() => {
-    setSelectedNode(undefined)
-  }, [])
 
   const { accountId: accountIdentifier, orgIdentifier, projectIdentifier } = useParams<ProjectPathProps>()
 
@@ -52,15 +56,50 @@ export function ExecutionVerificationView(props: ExecutionVerificationViewProps)
     lazy: true
   })
 
+  const {
+    data: healthSourcesData,
+    error: healthSourcesError,
+    loading: healthSourcesLoading,
+    refetch: fetchHealthSources
+  } = useGetHealthSourcesForVerifyStepExecutionId({
+    accountIdentifier,
+    orgIdentifier,
+    projectIdentifier,
+    verifyStepExecutionId: activityId,
+    lazy: true
+  })
+
+  const canEnableMetricsTab = getCanEnableMetricsTab(healthSourcesData)
+  const canEnableLogsTab = getCanEnableLogsTab(healthSourcesData)
+
+  // const defaultTabId = useMemo(
+  //   () => getDefaultTabId({ getString, tabName: type, canEnableMetricsTab, canEnableLogsTab }),
+  //   [canEnableLogsTab, canEnableMetricsTab, getString, type, healthSourcesLoading]
+  // )
+
+  const [selectedTab, setSelectedTab] = useState(() =>
+    getDefaultTabId({ getString, tabName: type, canEnableMetricsTab, canEnableLogsTab })
+  )
+
+  useEffect(() => {
+    setSelectedTab(getDefaultTabId({ getString, tabName: type, canEnableMetricsTab, canEnableLogsTab }))
+  }, [canEnableLogsTab, canEnableMetricsTab, getString, type])
+
+  const handleTabChange = useCallback(nextTabId => {
+    setSelectedNode(undefined)
+    setSelectedTab(nextTabId)
+  }, [])
+
   const content = activityId ? (
     <>
       <ManualInterventionVerifyStep step={step} />
       <InterruptedHistory interruptedHistories={step?.interruptHistories} />
-      <Tabs id="AnalysisTypeTabs" defaultSelectedTabId={defaultTabId} onChange={handleTabChange}>
+      <Tabs id="AnalysisTypeTabs" selectedTabId={selectedTab} onChange={handleTabChange}>
         <Tab
           id={getString('pipeline.verification.analysisTab.metrics')}
           title={getString('pipeline.verification.analysisTab.metrics')}
           panelClassName={css.mainTabPanel}
+          disabled={!canEnableMetricsTab}
           panel={
             <Layout.Horizontal style={{ height: '100%' }}>
               <ExecutionVerificationSummary
@@ -79,6 +118,10 @@ export function ExecutionVerificationView(props: ExecutionVerificationViewProps)
                 activityId={activityId}
                 overviewData={data}
                 overviewLoading={loading}
+                healthSourcesData={healthSourcesData}
+                healthSourcesError={healthSourcesError}
+                healthSourcesLoading={healthSourcesLoading}
+                fetchHealthSources={fetchHealthSources}
               />
             </Layout.Horizontal>
           }
@@ -86,6 +129,7 @@ export function ExecutionVerificationView(props: ExecutionVerificationViewProps)
         <Tab
           id={getString('pipeline.verification.analysisTab.logs')}
           title={getString('pipeline.verification.analysisTab.logs')}
+          disabled={!canEnableLogsTab}
           panel={
             <Layout.Horizontal style={{ height: '100%' }}>
               <ExecutionVerificationSummary

--- a/src/modules/85-cv/components/ExecutionVerification/ExecutionVerificationView.tsx
+++ b/src/modules/85-cv/components/ExecutionVerification/ExecutionVerificationView.tsx
@@ -31,6 +31,7 @@ import {
 } from './ExecutionVerificationView.utils'
 import { ManualInterventionVerifyStep } from './components/ManualInterventionVerifyStep/ManualInterventionVerifyStep'
 import InterruptedHistory from './components/InterruptedHistory/InterruptedHistory'
+import { LogsQueryParamName } from './ExecutionVerificationView.constants'
 import css from './ExecutionVerificationView.module.scss'
 
 interface ExecutionVerificationViewProps {
@@ -66,7 +67,7 @@ export function ExecutionVerificationView(props: ExecutionVerificationViewProps)
     orgIdentifier,
     projectIdentifier,
     verifyStepExecutionId: activityId,
-    lazy: true
+    lazy: type !== LogsQueryParamName
   })
 
   const canEnableMetricsTab = getCanEnableMetricsTab(healthSourcesData)

--- a/src/modules/85-cv/components/ExecutionVerification/ExecutionVerificationView.utils.ts
+++ b/src/modules/85-cv/components/ExecutionVerification/ExecutionVerificationView.utils.ts
@@ -36,22 +36,17 @@ export const getDefaultTabId = ({
   }
 }
 
-const isHealthSourcesPresent = (healthSources: HealthSourceV2[] | null): healthSources is NonNullable<Array<any>> => {
+const isHealthSourcesPresent = (healthSources: HealthSourceV2[] | null): healthSources is HealthSourceV2[] => {
   return Boolean(healthSources && Array.isArray(healthSources))
 }
 
-export const getCanEnableMetricsTab = (healthSources: HealthSourceV2[] | null): boolean => {
+export const getCanEnableTabByType = (
+  healthSources: HealthSourceV2[] | null,
+  type: typeof MetricsProviderType | typeof LogsProviderType
+): boolean => {
   if (!isHealthSourcesPresent(healthSources)) {
     return false
   }
 
-  return healthSources.some(healthSource => healthSource.providerType === MetricsProviderType)
-}
-
-export const getCanEnableLogsTab = (healthSources: HealthSourceV2[] | null): boolean => {
-  if (!isHealthSourcesPresent(healthSources)) {
-    return false
-  }
-
-  return healthSources.some(healthSource => healthSource.providerType === LogsProviderType)
+  return healthSources.some(healthSource => healthSource.providerType === type)
 }

--- a/src/modules/85-cv/components/ExecutionVerification/ExecutionVerificationView.utils.ts
+++ b/src/modules/85-cv/components/ExecutionVerification/ExecutionVerificationView.utils.ts
@@ -5,14 +5,53 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
+import { HealthSourceV2 } from 'services/cv'
+import { UseStringsReturn } from 'framework/strings'
 import type { ExecutionNode } from 'services/pipeline-ng'
-import type { StringsMap } from 'stringTypes'
+import { LogsProviderType, MetricsProviderType } from './ExecutionVerificationView.constants'
 
 export const getActivityId = (step: ExecutionNode): string => {
   return (step?.outcomes?.output?.activityId || step?.progressData?.activityId) as unknown as string
 }
 
-export const getDefaultTabId = (
-  getString: (key: keyof StringsMap, vars?: Record<string, any> | undefined) => string,
+export const getDefaultTabId = ({
+  getString,
+  canEnableMetricsTab,
+  canEnableLogsTab,
+  tabName
+}: {
+  getString: UseStringsReturn['getString']
   tabName?: string
-): string => (tabName ? tabName : getString('pipeline.verification.analysisTab.metrics'))
+  canEnableMetricsTab: boolean
+  canEnableLogsTab: boolean
+}): string => {
+  if (tabName) {
+    return tabName
+  } else if (canEnableMetricsTab) {
+    return getString('pipeline.verification.analysisTab.metrics')
+  } else if (canEnableLogsTab) {
+    return getString('pipeline.verification.analysisTab.logs')
+  } else {
+    return getString('pipeline.verification.analysisTab.metrics')
+  }
+}
+
+const isHealthSourcesPresent = (healthSources: HealthSourceV2[] | null): healthSources is NonNullable<Array<any>> => {
+  return Boolean(healthSources && Array.isArray(healthSources))
+}
+
+export const getCanEnableMetricsTab = (healthSources: HealthSourceV2[] | null): boolean => {
+  if (!isHealthSourcesPresent(healthSources)) {
+    return false
+  }
+
+  return healthSources.some(healthSource => healthSource.providerType === MetricsProviderType)
+}
+
+export const getCanEnableLogsTab = (healthSources: HealthSourceV2[] | null): boolean => {
+  if (!isHealthSourcesPresent(healthSources)) {
+    return false
+  }
+
+  return healthSources.some(healthSource => healthSource.providerType === LogsProviderType)
+}

--- a/src/modules/85-cv/components/ExecutionVerification/components/DeploymentMetrics/DeploymentMetrics.tsx
+++ b/src/modules/85-cv/components/ExecutionVerification/components/DeploymentMetrics/DeploymentMetrics.tsx
@@ -28,6 +28,7 @@ import cx from 'classnames'
 import { isEqual } from 'lodash-es'
 import { FontVariation, Color } from '@harness/design-system'
 import { useParams } from 'react-router-dom'
+import { GetDataError } from 'restful-react'
 import { useStrings } from 'framework/strings'
 import { useQueryParams } from '@common/hooks'
 import type { ProjectPathProps } from '@common/interfaces/RouteInterfaces'
@@ -35,6 +36,7 @@ import type { ExecutionNode } from 'services/pipeline-ng'
 import {
   AnalysedDeploymentNode,
   GetMetricsAnalysisForVerifyStepExecutionIdQueryParams,
+  HealthSourceV2,
   VerificationOverview,
   useGetHealthSourcesForVerifyStepExecutionId,
   useGetMetricsAnalysisForVerifyStepExecutionId,
@@ -80,6 +82,10 @@ interface DeploymentMetricsProps {
   selectedNode?: AnalysedDeploymentNode
   overviewData: VerificationOverview | null
   overviewLoading?: boolean
+  healthSourcesData: HealthSourceV2[] | null
+  healthSourcesError: GetDataError<unknown> | null
+  healthSourcesLoading: boolean
+  fetchHealthSources: () => Promise<void>
 }
 
 type UpdateViewState = {
@@ -90,7 +96,17 @@ type UpdateViewState = {
 }
 
 export function DeploymentMetrics(props: DeploymentMetricsProps): JSX.Element {
-  const { step, selectedNode, activityId, overviewData, overviewLoading } = props
+  const {
+    step,
+    selectedNode,
+    activityId,
+    overviewData,
+    overviewLoading,
+    fetchHealthSources,
+    healthSourcesData,
+    healthSourcesError,
+    healthSourcesLoading
+  } = props
   const { getString } = useStrings()
   const pageParams = useQueryParams<ExecutionQueryParams>()
 
@@ -176,18 +192,18 @@ export function DeploymentMetrics(props: DeploymentMetricsProps): JSX.Element {
     return getFilterDisplayText(selectedOptions, baseText, getString('all'))
   }, [])
 
-  const {
-    data: healthSourcesData,
-    error: healthSourcesError,
-    loading: healthSourcesLoading,
-    refetch: fetchHealthSources
-  } = useGetHealthSourcesForVerifyStepExecutionId({
-    accountIdentifier: accountId,
-    orgIdentifier,
-    projectIdentifier,
-    verifyStepExecutionId: activityId,
-    lazy: true
-  })
+  // const {
+  //   data: healthSourcesData,
+  //   error: healthSourcesError,
+  //   loading: healthSourcesLoading,
+  //   refetch: fetchHealthSources
+  // } = useGetHealthSourcesForVerifyStepExecutionId({
+  //   accountIdentifier: accountId,
+  //   orgIdentifier,
+  //   projectIdentifier,
+  //   verifyStepExecutionId: activityId,
+  //   lazy: true
+  // })
 
   useEffect(() => {
     if (activityId) {

--- a/src/modules/85-cv/components/ExecutionVerification/components/DeploymentMetrics/DeploymentMetrics.tsx
+++ b/src/modules/85-cv/components/ExecutionVerification/components/DeploymentMetrics/DeploymentMetrics.tsx
@@ -75,16 +75,20 @@ import type { StartTimestampDataType } from './DeploymentMetrics.types'
 
 import css from './DeploymentMetrics.module.scss'
 
+interface HealthSourcesDetailsType {
+  healthSourcesData: HealthSourceV2[] | null
+  healthSourcesError: GetDataError<unknown> | null
+  healthSourcesLoading: boolean
+  fetchHealthSources: () => Promise<void>
+}
+
 interface DeploymentMetricsProps {
   step: ExecutionNode
   activityId: string
   selectedNode?: AnalysedDeploymentNode
   overviewData: VerificationOverview | null
   overviewLoading?: boolean
-  healthSourcesData: HealthSourceV2[] | null
-  healthSourcesError: GetDataError<unknown> | null
-  healthSourcesLoading: boolean
-  fetchHealthSources: () => Promise<void>
+  healthSourceDetails: HealthSourcesDetailsType
 }
 
 type UpdateViewState = {
@@ -101,10 +105,7 @@ export function DeploymentMetrics(props: DeploymentMetricsProps): JSX.Element {
     activityId,
     overviewData,
     overviewLoading,
-    fetchHealthSources,
-    healthSourcesData,
-    healthSourcesError,
-    healthSourcesLoading
+    healthSourceDetails: { fetchHealthSources, healthSourcesData, healthSourcesError, healthSourcesLoading }
   } = props
   const { getString } = useStrings()
   const pageParams = useQueryParams<ExecutionQueryParams>()

--- a/src/modules/85-cv/components/ExecutionVerification/components/DeploymentMetrics/DeploymentMetrics.tsx
+++ b/src/modules/85-cv/components/ExecutionVerification/components/DeploymentMetrics/DeploymentMetrics.tsx
@@ -38,7 +38,6 @@ import {
   GetMetricsAnalysisForVerifyStepExecutionIdQueryParams,
   HealthSourceV2,
   VerificationOverview,
-  useGetHealthSourcesForVerifyStepExecutionId,
   useGetMetricsAnalysisForVerifyStepExecutionId,
   useGetTransactionGroupsForVerifyStepExecutionId,
   useGetVerifyStepNodeNames
@@ -191,19 +190,6 @@ export function DeploymentMetrics(props: DeploymentMetricsProps): JSX.Element {
     const baseText = getString(filterText)
     return getFilterDisplayText(selectedOptions, baseText, getString('all'))
   }, [])
-
-  // const {
-  //   data: healthSourcesData,
-  //   error: healthSourcesError,
-  //   loading: healthSourcesLoading,
-  //   refetch: fetchHealthSources
-  // } = useGetHealthSourcesForVerifyStepExecutionId({
-  //   accountIdentifier: accountId,
-  //   orgIdentifier,
-  //   projectIdentifier,
-  //   verifyStepExecutionId: activityId,
-  //   lazy: true
-  // })
 
   useEffect(() => {
     if (activityId) {

--- a/src/modules/85-cv/components/ExecutionVerification/components/DeploymentMetrics/__tests__/DeploymentMetrics.test.tsx
+++ b/src/modules/85-cv/components/ExecutionVerification/components/DeploymentMetrics/__tests__/DeploymentMetrics.test.tsx
@@ -198,10 +198,12 @@ describe('Unit tests for Deployment metrics ', () => {
           step={MockExecutionNode}
           activityId={MockExecutionNode!.progressData!.activityId as unknown as string}
           overviewData={null}
-          healthSourcesError={null}
-          fetchHealthSources={useGetHealthSourcesSpy}
-          healthSourcesData={HealthSourcesResponse}
-          healthSourcesLoading={false}
+          healthSourceDetails={{
+            healthSourcesError: null,
+            fetchHealthSources: useGetHealthSourcesSpy,
+            healthSourcesData: HealthSourcesResponse,
+            healthSourcesLoading: false
+          }}
         />
       </TestWrapper>
     )
@@ -277,10 +279,12 @@ describe('Unit tests for Deployment metrics ', () => {
           step={MockExecutionNode}
           activityId={MockExecutionNode!.progressData!.activityId as unknown as string}
           overviewData={null}
-          healthSourcesError={null}
-          fetchHealthSources={useGetHealthSourcesSpy}
-          healthSourcesData={HealthSourcesResponse}
-          healthSourcesLoading={false}
+          healthSourceDetails={{
+            healthSourcesError: null,
+            fetchHealthSources: useGetHealthSourcesSpy,
+            healthSourcesData: HealthSourcesResponse,
+            healthSourcesLoading: false
+          }}
         />
       </TestWrapper>
     )
@@ -342,10 +346,12 @@ describe('Unit tests for Deployment metrics ', () => {
           step={MockExecutionNode}
           activityId={MockExecutionNode!.progressData!.activityId as unknown as string}
           overviewData={null}
-          healthSourcesError={null}
-          fetchHealthSources={useGetHealthSourcesSpy}
-          healthSourcesData={HealthSourcesResponse}
-          healthSourcesLoading={false}
+          healthSourceDetails={{
+            healthSourcesError: null,
+            fetchHealthSources: useGetHealthSourcesSpy,
+            healthSourcesData: HealthSourcesResponse,
+            healthSourcesLoading: false
+          }}
         />
       </TestWrapper>
     )
@@ -378,10 +384,12 @@ describe('Unit tests for Deployment metrics ', () => {
           step={MockExecutionNode}
           activityId={MockExecutionNode!.progressData!.activityId as unknown as string}
           overviewData={null}
-          healthSourcesError={null}
-          fetchHealthSources={useGetHealthSourcesSpy}
-          healthSourcesData={HealthSourcesResponse}
-          healthSourcesLoading={false}
+          healthSourceDetails={{
+            healthSourcesError: null,
+            fetchHealthSources: useGetHealthSourcesSpy,
+            healthSourcesData: HealthSourcesResponse,
+            healthSourcesLoading: false
+          }}
         />
       </TestWrapper>
     )
@@ -419,10 +427,12 @@ describe('Unit tests for Deployment metrics ', () => {
           step={MockExecutionNode}
           activityId={MockExecutionNode!.progressData!.activityId as unknown as string}
           overviewData={null}
-          healthSourcesError={null}
-          fetchHealthSources={useGetHealthSourcesSpy}
-          healthSourcesData={HealthSourcesResponse}
-          healthSourcesLoading={false}
+          healthSourceDetails={{
+            healthSourcesError: null,
+            fetchHealthSources: useGetHealthSourcesSpy,
+            healthSourcesData: HealthSourcesResponse,
+            healthSourcesLoading: false
+          }}
         />
       </TestWrapper>
     )
@@ -458,10 +468,12 @@ describe('Unit tests for Deployment metrics ', () => {
           step={MockExecutionNode}
           activityId={MockExecutionNode!.progressData!.activityId as unknown as string}
           overviewData={null}
-          healthSourcesError={null}
-          fetchHealthSources={useGetHealthSourcesSpy}
-          healthSourcesData={HealthSourcesResponse}
-          healthSourcesLoading={false}
+          healthSourceDetails={{
+            healthSourcesError: null,
+            fetchHealthSources: useGetHealthSourcesSpy,
+            healthSourcesData: HealthSourcesResponse,
+            healthSourcesLoading: false
+          }}
         />
       </TestWrapper>
     )
@@ -514,10 +526,12 @@ describe('Unit tests for Deployment metrics ', () => {
           step={clonedNode}
           activityId={clonedNode!.progressData!.activityId as unknown as string}
           overviewData={null}
-          healthSourcesError={null}
-          fetchHealthSources={useGetHealthSourcesSpy}
-          healthSourcesData={HealthSourcesResponse}
-          healthSourcesLoading={false}
+          healthSourceDetails={{
+            healthSourcesError: null,
+            fetchHealthSources: useGetHealthSourcesSpy,
+            healthSourcesData: HealthSourcesResponse,
+            healthSourcesLoading: false
+          }}
         />
       </TestWrapper>
     )
@@ -667,10 +681,12 @@ describe('Unit tests for Deployment metrics ', () => {
           step={MockExecutionNode}
           activityId={MockExecutionNode!.progressData!.activityId as unknown as string}
           overviewData={null}
-          healthSourcesError={null}
-          fetchHealthSources={useGetHealthSourcesSpy}
-          healthSourcesData={HealthSourcesResponse}
-          healthSourcesLoading={false}
+          healthSourceDetails={{
+            healthSourcesError: null,
+            fetchHealthSources: useGetHealthSourcesSpy,
+            healthSourcesData: HealthSourcesResponse,
+            healthSourcesLoading: false
+          }}
         />
       </TestWrapper>
     )
@@ -708,10 +724,12 @@ describe('Unit tests for Deployment metrics ', () => {
           step={MockExecutionNode}
           activityId={MockExecutionNode!.progressData!.activityId as unknown as string}
           overviewData={null}
-          healthSourcesError={null}
-          fetchHealthSources={useGetHealthSourcesSpy}
-          healthSourcesData={HealthSourcesResponse}
-          healthSourcesLoading={false}
+          healthSourceDetails={{
+            healthSourcesError: null,
+            fetchHealthSources: useGetHealthSourcesSpy,
+            healthSourcesData: HealthSourcesResponse,
+            healthSourcesLoading: false
+          }}
         />
       </TestWrapper>
     )
@@ -762,10 +780,12 @@ describe('Unit tests for Deployment metrics ', () => {
             step={MockExecutionNode}
             activityId={MockExecutionNode!.progressData!.activityId as unknown as string}
             overviewData={overviewDataMock}
-            healthSourcesError={null}
-            fetchHealthSources={useGetHealthSourcesSpy}
-            healthSourcesData={HealthSourcesResponse}
-            healthSourcesLoading={false}
+            healthSourceDetails={{
+              healthSourcesError: null,
+              fetchHealthSources: useGetHealthSourcesSpy,
+              healthSourcesData: HealthSourcesResponse,
+              healthSourcesLoading: false
+            }}
           />
         </TestWrapper>
       )

--- a/src/modules/85-cv/components/ExecutionVerification/components/DeploymentMetrics/__tests__/DeploymentMetrics.test.tsx
+++ b/src/modules/85-cv/components/ExecutionVerification/components/DeploymentMetrics/__tests__/DeploymentMetrics.test.tsx
@@ -132,7 +132,7 @@ const ApiResponse = {
   empty: false
 }
 
-const HealthSourcesResponse = [
+const HealthSourcesResponse: cvService.HealthSourceV2[] = [
   {
     identifier: 'KQE5GbbKTD6w39T6_jwUog/Templatised_sumologic_metrics_health_source',
     name: 'Templatised sumologic metrics health source',
@@ -171,12 +171,7 @@ describe('Unit tests for Deployment metrics ', () => {
   })
 
   test('Ensure api is called with non anomalous filter', async () => {
-    const useGetHealthSourcesSpy = jest
-      .spyOn(cvService, 'useGetHealthSourcesForVerifyStepExecutionId')
-      .mockReturnValue({
-        data: HealthSourcesResponse,
-        refetch: jest.fn() as unknown
-      } as any)
+    const useGetHealthSourcesSpy = jest.fn()
 
     const useGetDeploymentMetricsSpy = jest
       .spyOn(cvService, 'useGetMetricsAnalysisForVerifyStepExecutionId')
@@ -203,6 +198,10 @@ describe('Unit tests for Deployment metrics ', () => {
           step={MockExecutionNode}
           activityId={MockExecutionNode!.progressData!.activityId as unknown as string}
           overviewData={null}
+          healthSourcesError={null}
+          fetchHealthSources={useGetHealthSourcesSpy}
+          healthSourcesData={HealthSourcesResponse}
+          healthSourcesLoading={false}
         />
       </TestWrapper>
     )
@@ -253,10 +252,7 @@ describe('Unit tests for Deployment metrics ', () => {
   })
 
   test('Ensure api is called with filter and selected page', async () => {
-    jest.spyOn(cvService, 'useGetHealthSourcesForVerifyStepExecutionId').mockReturnValue({
-      data: HealthSourcesResponse,
-      refetch: jest.fn() as unknown
-    } as any)
+    const useGetHealthSourcesSpy = jest.fn()
 
     const useGetDeploymentMetricsSpy = jest
       .spyOn(cvService, 'useGetMetricsAnalysisForVerifyStepExecutionId')
@@ -281,6 +277,10 @@ describe('Unit tests for Deployment metrics ', () => {
           step={MockExecutionNode}
           activityId={MockExecutionNode!.progressData!.activityId as unknown as string}
           overviewData={null}
+          healthSourcesError={null}
+          fetchHealthSources={useGetHealthSourcesSpy}
+          healthSourcesData={HealthSourcesResponse}
+          healthSourcesLoading={false}
         />
       </TestWrapper>
     )
@@ -319,10 +319,7 @@ describe('Unit tests for Deployment metrics ', () => {
   })
 
   test('Ensure loading state is rendered', async () => {
-    jest.spyOn(cvService, 'useGetHealthSourcesForVerifyStepExecutionId').mockReturnValue({
-      data: HealthSourcesResponse,
-      refetch: jest.fn() as unknown
-    } as any)
+    const useGetHealthSourcesSpy = jest.fn()
 
     jest.spyOn(cvService, 'useGetMetricsAnalysisForVerifyStepExecutionId').mockReturnValue({
       loading: true,
@@ -345,6 +342,10 @@ describe('Unit tests for Deployment metrics ', () => {
           step={MockExecutionNode}
           activityId={MockExecutionNode!.progressData!.activityId as unknown as string}
           overviewData={null}
+          healthSourcesError={null}
+          fetchHealthSources={useGetHealthSourcesSpy}
+          healthSourcesData={HealthSourcesResponse}
+          healthSourcesLoading={false}
         />
       </TestWrapper>
     )
@@ -353,10 +354,7 @@ describe('Unit tests for Deployment metrics ', () => {
   })
 
   test('Ensure error state is rendred', async () => {
-    jest.spyOn(cvService, 'useGetHealthSourcesForVerifyStepExecutionId').mockReturnValue({
-      data: HealthSourcesResponse,
-      refetch: jest.fn() as unknown
-    } as any)
+    const useGetHealthSourcesSpy = jest.fn()
 
     const refetchFn = jest.fn()
     jest.spyOn(cvService, 'useGetMetricsAnalysisForVerifyStepExecutionId').mockReturnValue({
@@ -380,6 +378,10 @@ describe('Unit tests for Deployment metrics ', () => {
           step={MockExecutionNode}
           activityId={MockExecutionNode!.progressData!.activityId as unknown as string}
           overviewData={null}
+          healthSourcesError={null}
+          fetchHealthSources={useGetHealthSourcesSpy}
+          healthSourcesData={HealthSourcesResponse}
+          healthSourcesLoading={false}
         />
       </TestWrapper>
     )
@@ -392,10 +394,7 @@ describe('Unit tests for Deployment metrics ', () => {
   })
 
   test('Ensure no data state is rendered', async () => {
-    jest.spyOn(cvService, 'useGetHealthSourcesForVerifyStepExecutionId').mockReturnValue({
-      data: HealthSourcesResponse,
-      refetch: jest.fn() as unknown
-    } as any)
+    const useGetHealthSourcesSpy = jest.fn()
 
     const refetchFn = jest.fn()
     jest.spyOn(cvService, 'useGetMetricsAnalysisForVerifyStepExecutionId').mockReturnValue({
@@ -420,6 +419,10 @@ describe('Unit tests for Deployment metrics ', () => {
           step={MockExecutionNode}
           activityId={MockExecutionNode!.progressData!.activityId as unknown as string}
           overviewData={null}
+          healthSourcesError={null}
+          fetchHealthSources={useGetHealthSourcesSpy}
+          healthSourcesData={HealthSourcesResponse}
+          healthSourcesLoading={false}
         />
       </TestWrapper>
     )
@@ -429,10 +432,7 @@ describe('Unit tests for Deployment metrics ', () => {
   })
 
   test('Ensure that when new activityId is passed as prop view is reset', async () => {
-    jest.spyOn(cvService, 'useGetHealthSourcesForVerifyStepExecutionId').mockReturnValue({
-      data: HealthSourcesResponse,
-      refetch: jest.fn() as unknown
-    } as any)
+    const useGetHealthSourcesSpy = jest.fn()
 
     const refetchFn = jest.fn()
     const useGetDeploymentMetricsSpy = jest
@@ -458,6 +458,10 @@ describe('Unit tests for Deployment metrics ', () => {
           step={MockExecutionNode}
           activityId={MockExecutionNode!.progressData!.activityId as unknown as string}
           overviewData={null}
+          healthSourcesError={null}
+          fetchHealthSources={useGetHealthSourcesSpy}
+          healthSourcesData={HealthSourcesResponse}
+          healthSourcesLoading={false}
         />
       </TestWrapper>
     )
@@ -483,10 +487,7 @@ describe('Unit tests for Deployment metrics ', () => {
   })
 
   test('Ensure polling works correctly', async () => {
-    jest.spyOn(cvService, 'useGetHealthSourcesForVerifyStepExecutionId').mockReturnValue({
-      data: HealthSourcesResponse,
-      refetch: jest.fn() as unknown
-    } as any)
+    const useGetHealthSourcesSpy = jest.fn()
 
     const refetchFn = jest.fn()
     const clonedNode = cloneDeep(MockExecutionNode)
@@ -513,6 +514,10 @@ describe('Unit tests for Deployment metrics ', () => {
           step={clonedNode}
           activityId={clonedNode!.progressData!.activityId as unknown as string}
           overviewData={null}
+          healthSourcesError={null}
+          fetchHealthSources={useGetHealthSourcesSpy}
+          healthSourcesData={HealthSourcesResponse}
+          healthSourcesLoading={false}
         />
       </TestWrapper>
     )
@@ -639,10 +644,7 @@ describe('Unit tests for Deployment metrics ', () => {
   })
 
   test('should render accordion to display metrics', () => {
-    jest.spyOn(cvService, 'useGetHealthSourcesForVerifyStepExecutionId').mockReturnValue({
-      data: HealthSourcesResponse,
-      refetch: jest.fn() as unknown
-    } as any)
+    const useGetHealthSourcesSpy = jest.fn()
 
     jest.spyOn(cvService, 'useGetMetricsAnalysisForVerifyStepExecutionId').mockReturnValue({
       data: ApiResponse,
@@ -665,6 +667,10 @@ describe('Unit tests for Deployment metrics ', () => {
           step={MockExecutionNode}
           activityId={MockExecutionNode!.progressData!.activityId as unknown as string}
           overviewData={null}
+          healthSourcesError={null}
+          fetchHealthSources={useGetHealthSourcesSpy}
+          healthSourcesData={HealthSourcesResponse}
+          healthSourcesLoading={false}
         />
       </TestWrapper>
     )
@@ -677,10 +683,7 @@ describe('Unit tests for Deployment metrics ', () => {
     // @ts-ignore
     useQueryParams.mockImplementation(() => ({ filterAnomalous: 'true' }))
 
-    jest.spyOn(cvService, 'useGetHealthSourcesForVerifyStepExecutionId').mockReturnValue({
-      data: HealthSourcesResponse,
-      refetch: jest.fn() as unknown
-    } as any)
+    const useGetHealthSourcesSpy = jest.fn()
 
     const useGetDeploymentMetricsSpy = jest
       .spyOn(cvService, 'useGetMetricsAnalysisForVerifyStepExecutionId')
@@ -705,6 +708,10 @@ describe('Unit tests for Deployment metrics ', () => {
           step={MockExecutionNode}
           activityId={MockExecutionNode!.progressData!.activityId as unknown as string}
           overviewData={null}
+          healthSourcesError={null}
+          fetchHealthSources={useGetHealthSourcesSpy}
+          healthSourcesData={HealthSourcesResponse}
+          healthSourcesLoading={false}
         />
       </TestWrapper>
     )
@@ -732,10 +739,7 @@ describe('Unit tests for Deployment metrics ', () => {
 
   describe('Simple verification changes', () => {
     test('should not render nodes filter', () => {
-      jest.spyOn(cvService, 'useGetHealthSourcesForVerifyStepExecutionId').mockReturnValue({
-        data: HealthSourcesResponse,
-        refetch: jest.fn() as unknown
-      } as any)
+      const useGetHealthSourcesSpy = jest.fn()
 
       jest.spyOn(cvService, 'useGetMetricsAnalysisForVerifyStepExecutionId').mockReturnValue({
         data: ApiResponse,
@@ -758,6 +762,10 @@ describe('Unit tests for Deployment metrics ', () => {
             step={MockExecutionNode}
             activityId={MockExecutionNode!.progressData!.activityId as unknown as string}
             overviewData={overviewDataMock}
+            healthSourcesError={null}
+            fetchHealthSources={useGetHealthSourcesSpy}
+            healthSourcesData={HealthSourcesResponse}
+            healthSourcesLoading={false}
           />
         </TestWrapper>
       )

--- a/src/modules/85-cv/components/ExecutionVerification/tests/ExecutionVerificationView.mock.ts
+++ b/src/modules/85-cv/components/ExecutionVerification/tests/ExecutionVerificationView.mock.ts
@@ -1,0 +1,29 @@
+import { HealthSourceV2 } from 'services/cv'
+
+export const HealthSourcesResponse: HealthSourceV2[] = [
+  {
+    identifier: 'a',
+    name: 'Templatised sumologic metrics health source',
+    type: 'SumologicMetrics',
+    providerType: 'METRICS'
+  },
+  {
+    identifier: 'b',
+    name: 'Templatised sumologic logs health source',
+    type: 'SumologicLogs',
+    providerType: 'LOGS'
+  }
+]
+
+export const expectedHealthSourcesParams = {
+  accountIdentifier: 'acc',
+  lazy: false,
+  orgIdentifier: 'org',
+  projectIdentifier: 'project',
+  verifyStepExecutionId: '1234_activityId'
+}
+
+export const expectedHealthSourcesParamsWithMetrics = {
+  ...expectedHealthSourcesParams,
+  lazy: true
+}

--- a/src/modules/85-cv/components/ExecutionVerification/tests/ExecutionVerificationView.test.tsx
+++ b/src/modules/85-cv/components/ExecutionVerification/tests/ExecutionVerificationView.test.tsx
@@ -89,18 +89,22 @@ describe('Unit tests for ExecutionVerificationView unit tests', () => {
   })
 
   test('Ensure correct tabId is returned  ', () => {
-    jest.mock('framework/strings', () => ({
-      useStrings: () => ({
-        getString: (val: string) => val
-      })
-    }))
-    expect(getDefaultTabId((item: string) => item, undefined)).toEqual('pipeline.verification.analysisTab.metrics')
-    expect(getDefaultTabId((item: string) => item, 'pipeline.verification.analysisTab.logs')).toEqual(
-      'pipeline.verification.analysisTab.logs'
-    )
-    expect(getDefaultTabId((item: string) => item, 'pipeline.verification.analysisTab.metrics')).toEqual(
+    expect(getDefaultTabId({ getString: key => key, canEnableLogsTab: false, canEnableMetricsTab: true })).toEqual(
       'pipeline.verification.analysisTab.metrics'
     )
+
+    expect(
+      getDefaultTabId({
+        getString: key => key,
+        tabName: 'pipeline.verification.analysisTab.logs',
+        canEnableLogsTab: true,
+        canEnableMetricsTab: true
+      })
+    ).toEqual('pipeline.verification.analysisTab.logs')
+
+    expect(
+      getDefaultTabId({ getString: (item: string) => item, canEnableMetricsTab: false, canEnableLogsTab: true })
+    ).toEqual('pipeline.verification.analysisTab.logs')
   })
 
   test('Ensure correct tabs are rendered via queryParams', async () => {

--- a/src/modules/85-cv/components/ExecutionVerification/tests/ExecutionVerificationView.test.tsx
+++ b/src/modules/85-cv/components/ExecutionVerification/tests/ExecutionVerificationView.test.tsx
@@ -10,12 +10,19 @@ import userEvent from '@testing-library/user-event'
 import { render, waitFor, screen } from '@testing-library/react'
 import { findDialogContainer, TestWrapper } from '@common/utils/testUtils'
 import type { ExecutionNode } from 'services/pipeline-ng'
+import * as cvService from 'services/cv'
+import * as commonHooks from '@common/hooks'
 import {
   LogTypes,
   SLOLogContentProps,
   VerifyStepLogContentProps
 } from '@cv/hooks/useLogContentHook/useLogContentHook.types'
 import { ExecutionVerificationView } from '../ExecutionVerificationView'
+import {
+  HealthSourcesResponse,
+  expectedHealthSourcesParams,
+  expectedHealthSourcesParamsWithMetrics
+} from './ExecutionVerificationView.mock'
 import { getActivityId, getDefaultTabId } from '../ExecutionVerificationView.utils'
 
 jest.mock('../components/DeploymentMetrics/DeploymentMetrics', () => ({
@@ -168,5 +175,55 @@ describe('Unit tests for ExecutionVerificationView unit tests', () => {
     })
 
     await userEvent.click(dialog?.querySelector('[data-icon="Stroke"]')!)
+  })
+
+  test('should make health sources API call if user opens logs tabs directly', async () => {
+    jest.spyOn(commonHooks, 'useQueryParams').mockImplementation(() => ({ type: 'Logs' }))
+
+    const useGetHealthSourcesForVerifyStepExecutionIdSpy = jest
+      .spyOn(cvService, 'useGetHealthSourcesForVerifyStepExecutionId')
+      .mockReturnValue({
+        data: HealthSourcesResponse,
+        refetch: jest.fn() as unknown
+      } as any)
+
+    render(
+      <TestWrapper
+        path="/:accountId/:orgIdentifier/:projectIdentifier"
+        pathParams={{ accountId: 'acc', orgIdentifier: 'org', projectIdentifier: 'project' }}
+      >
+        <ExecutionVerificationView step={{ progressData: { activityId: '1234_activityId' as any } }} />
+      </TestWrapper>
+    )
+
+    await waitFor(() =>
+      expect(useGetHealthSourcesForVerifyStepExecutionIdSpy).toHaveBeenCalledWith(expectedHealthSourcesParams)
+    )
+  })
+
+  test('should call health sources API call as lazy if user opens Metrics tabs directly', async () => {
+    jest.spyOn(commonHooks, 'useQueryParams').mockImplementation(() => ({ type: 'Metrics' }))
+
+    const useGetHealthSourcesForVerifyStepExecutionIdSpy = jest
+      .spyOn(cvService, 'useGetHealthSourcesForVerifyStepExecutionId')
+      .mockReturnValue({
+        data: HealthSourcesResponse,
+        refetch: jest.fn() as unknown
+      } as any)
+
+    render(
+      <TestWrapper
+        path="/:accountId/:orgIdentifier/:projectIdentifier"
+        pathParams={{ accountId: 'acc', orgIdentifier: 'org', projectIdentifier: 'project' }}
+      >
+        <ExecutionVerificationView step={{ progressData: { activityId: '1234_activityId' as any } }} />
+      </TestWrapper>
+    )
+
+    await waitFor(() =>
+      expect(useGetHealthSourcesForVerifyStepExecutionIdSpy).toHaveBeenCalledWith(
+        expectedHealthSourcesParamsWithMetrics
+      )
+    )
   })
 })

--- a/src/modules/85-cv/components/ExecutionVerification/tests/__snapshots__/ExecutionVerificationView.test.tsx.snap
+++ b/src/modules/85-cv/components/ExecutionVerification/tests/__snapshots__/ExecutionVerificationView.test.tsx.snap
@@ -22,27 +22,25 @@ exports[`Unit tests for ExecutionVerificationView unit tests Ensure correct tabs
         </div>
         <div
           aria-controls="bp3-tab-panel_AnalysisTypeTabs_pipeline.verification.analysisTab.metrics"
-          aria-disabled="false"
+          aria-disabled="true"
           aria-expanded="false"
           aria-selected="false"
           class="bp3-tab"
           data-tab-id="pipeline.verification.analysisTab.metrics"
           id="bp3-tab-title_AnalysisTypeTabs_pipeline.verification.analysisTab.metrics"
           role="tab"
-          tabindex="0"
         >
           pipeline.verification.analysisTab.metrics
         </div>
         <div
           aria-controls="bp3-tab-panel_AnalysisTypeTabs_pipeline.verification.analysisTab.logs"
-          aria-disabled="false"
+          aria-disabled="true"
           aria-expanded="true"
           aria-selected="true"
           class="bp3-tab"
           data-tab-id="pipeline.verification.analysisTab.logs"
           id="bp3-tab-title_AnalysisTypeTabs_pipeline.verification.analysisTab.logs"
           role="tab"
-          tabindex="0"
         >
           pipeline.verification.analysisTab.logs
         </div>
@@ -191,27 +189,25 @@ exports[`Unit tests for ExecutionVerificationView unit tests Ensure correct tabs
         </div>
         <div
           aria-controls="bp3-tab-panel_AnalysisTypeTabs_pipeline.verification.analysisTab.metrics"
-          aria-disabled="false"
+          aria-disabled="true"
           aria-expanded="true"
           aria-selected="true"
           class="bp3-tab"
           data-tab-id="pipeline.verification.analysisTab.metrics"
           id="bp3-tab-title_AnalysisTypeTabs_pipeline.verification.analysisTab.metrics"
           role="tab"
-          tabindex="0"
         >
           pipeline.verification.analysisTab.metrics
         </div>
         <div
           aria-controls="bp3-tab-panel_AnalysisTypeTabs_pipeline.verification.analysisTab.logs"
-          aria-disabled="false"
+          aria-disabled="true"
           aria-expanded="false"
           aria-selected="false"
           class="bp3-tab"
           data-tab-id="pipeline.verification.analysisTab.logs"
           id="bp3-tab-title_AnalysisTypeTabs_pipeline.verification.analysisTab.logs"
           role="tab"
-          tabindex="0"
         >
           pipeline.verification.analysisTab.logs
         </div>
@@ -409,27 +405,25 @@ exports[`Unit tests for ExecutionVerificationView unit tests Ensure tabs are ren
         </div>
         <div
           aria-controls="bp3-tab-panel_AnalysisTypeTabs_pipeline.verification.analysisTab.metrics"
-          aria-disabled="false"
+          aria-disabled="true"
           aria-expanded="true"
           aria-selected="true"
           class="bp3-tab"
           data-tab-id="pipeline.verification.analysisTab.metrics"
           id="bp3-tab-title_AnalysisTypeTabs_pipeline.verification.analysisTab.metrics"
           role="tab"
-          tabindex="0"
         >
           pipeline.verification.analysisTab.metrics
         </div>
         <div
           aria-controls="bp3-tab-panel_AnalysisTypeTabs_pipeline.verification.analysisTab.logs"
-          aria-disabled="false"
+          aria-disabled="true"
           aria-expanded="false"
           aria-selected="false"
           class="bp3-tab"
           data-tab-id="pipeline.verification.analysisTab.logs"
           id="bp3-tab-title_AnalysisTypeTabs_pipeline.verification.analysisTab.logs"
           role="tab"
-          tabindex="0"
         >
           pipeline.verification.analysisTab.logs
         </div>


### PR DESCRIPTION

### Summary

<!-- ✍️ A clear and concise description...-->

#### Screenshots

<img width="1693" alt="image" src="https://github.com/harness/harness-core-ui/assets/95267551/94e647a2-aec8-4d3d-b621-665ff1770d27">

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
