### PR TITLE
fix: [OIP-752]: Switch verification tabs by default based on the health source configuration

### DIFF
--- a/src/modules/85-cv/components/ExecutionVerification/ExecutionVerificationView.constants.ts
+++ b/src/modules/85-cv/components/ExecutionVerification/ExecutionVerificationView.constants.ts
@@ -1,0 +1,2 @@
+export const MetricsProviderType = 'METRICS'
+export const LogsProviderType = 'LOGS'

--- a/src/modules/85-cv/components/ExecutionVerification/ExecutionVerificationView.tsx
+++ b/src/modules/85-cv/components/ExecutionVerification/ExecutionVerificationView.tsx
@@ -5,7 +5,7 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import React, { useMemo, useState, useCallback } from 'react'
+import React, { useMemo, useState, useCallback, useEffect } from 'react'
 import { useParams } from 'react-router-dom'
 import { Container, Tabs, Tab, NoDataCard, Layout, FlexExpander, Button, ButtonVariation } from '@harness/uicore'
 import { Color } from '@harness/design-system'
@@ -15,11 +15,20 @@ import type { ExecutionNode } from 'services/pipeline-ng'
 import { useLogContentHook } from '@cv/hooks/useLogContentHook/useLogContentHook'
 import type { ProjectPathProps } from '@common/interfaces/RouteInterfaces'
 import { LogTypes } from '@cv/hooks/useLogContentHook/useLogContentHook.types'
-import { AnalysedDeploymentNode, useGetVerificationOverviewForVerifyStepExecutionId } from 'services/cv'
+import {
+  AnalysedDeploymentNode,
+  useGetVerificationOverviewForVerifyStepExecutionId,
+  useGetHealthSourcesForVerifyStepExecutionId
+} from 'services/cv'
 import { DeploymentMetrics } from './components/DeploymentMetrics/DeploymentMetrics'
 import { ExecutionVerificationSummary } from './components/ExecutionVerificationSummary/ExecutionVerificationSummary'
 import LogAnalysisContainer from './components/LogAnalysisContainer/LogAnalysisView.container'
-import { getActivityId, getDefaultTabId } from './ExecutionVerificationView.utils'
+import {
+  getActivityId,
+  getCanEnableLogsTab,
+  getCanEnableMetricsTab,
+  getDefaultTabId
+} from './ExecutionVerificationView.utils'
 import { ManualInterventionVerifyStep } from './components/ManualInterventionVerifyStep/ManualInterventionVerifyStep'
 import InterruptedHistory from './components/InterruptedHistory/InterruptedHistory'
 import css from './ExecutionVerificationView.module.scss'
@@ -34,13 +43,8 @@ export function ExecutionVerificationView(props: ExecutionVerificationViewProps)
   const [selectedNode, setSelectedNode] = useState<AnalysedDeploymentNode | undefined>()
   const activityId = useMemo(() => getActivityId(step), [step])
   const { type } = useQueryParams<{ type?: string }>()
-  const defaultTabId = useMemo(() => getDefaultTabId(getString, type), [type])
 
   const { openLogContentHook } = useLogContentHook({ verifyStepExecutionId: activityId })
-
-  const handleTabChange = useCallback(() => {
-    setSelectedNode(undefined)
-  }, [])
 
   const { accountId: accountIdentifier, orgIdentifier, projectIdentifier } = useParams<ProjectPathProps>()
 
@@ -52,15 +56,50 @@ export function ExecutionVerificationView(props: ExecutionVerificationViewProps)
     lazy: true
   })
 
+  const {
+    data: healthSourcesData,
+    error: healthSourcesError,
+    loading: healthSourcesLoading,
+    refetch: fetchHealthSources
+  } = useGetHealthSourcesForVerifyStepExecutionId({
+    accountIdentifier,
+    orgIdentifier,
+    projectIdentifier,
+    verifyStepExecutionId: activityId,
+    lazy: true
+  })
+
+  const canEnableMetricsTab = getCanEnableMetricsTab(healthSourcesData)
+  const canEnableLogsTab = getCanEnableLogsTab(healthSourcesData)
+
+  // const defaultTabId = useMemo(
+  //   () => getDefaultTabId({ getString, tabName: type, canEnableMetricsTab, canEnableLogsTab }),
+  //   [canEnableLogsTab, canEnableMetricsTab, getString, type, healthSourcesLoading]
+  // )
+
+  const [selectedTab, setSelectedTab] = useState(() =>
+    getDefaultTabId({ getString, tabName: type, canEnableMetricsTab, canEnableLogsTab })
+  )
+
+  useEffect(() => {
+    setSelectedTab(getDefaultTabId({ getString, tabName: type, canEnableMetricsTab, canEnableLogsTab }))
+  }, [canEnableLogsTab, canEnableMetricsTab, getString, type])
+
+  const handleTabChange = useCallback(nextTabId => {
+    setSelectedNode(undefined)
+    setSelectedTab(nextTabId)
+  }, [])
+
   const content = activityId ? (
     <>
       <ManualInterventionVerifyStep step={step} />
       <InterruptedHistory interruptedHistories={step?.interruptHistories} />
-      <Tabs id="AnalysisTypeTabs" defaultSelectedTabId={defaultTabId} onChange={handleTabChange}>
+      <Tabs id="AnalysisTypeTabs" selectedTabId={selectedTab} onChange={handleTabChange}>
         <Tab
           id={getString('pipeline.verification.analysisTab.metrics')}
           title={getString('pipeline.verification.analysisTab.metrics')}
           panelClassName={css.mainTabPanel}
+          disabled={!canEnableMetricsTab}
           panel={
             <Layout.Horizontal style={{ height: '100%' }}>
               <ExecutionVerificationSummary
@@ -79,6 +118,10 @@ export function ExecutionVerificationView(props: ExecutionVerificationViewProps)
                 activityId={activityId}
                 overviewData={data}
                 overviewLoading={loading}
+                healthSourcesData={healthSourcesData}
+                healthSourcesError={healthSourcesError}
+                healthSourcesLoading={healthSourcesLoading}
+                fetchHealthSources={fetchHealthSources}
               />
             </Layout.Horizontal>
           }
@@ -86,6 +129,7 @@ export function ExecutionVerificationView(props: ExecutionVerificationViewProps)
         <Tab
           id={getString('pipeline.verification.analysisTab.logs')}
           title={getString('pipeline.verification.analysisTab.logs')}
+          disabled={!canEnableLogsTab}
           panel={
             <Layout.Horizontal style={{ height: '100%' }}>
               <ExecutionVerificationSummary

--- a/src/modules/85-cv/components/ExecutionVerification/ExecutionVerificationView.utils.ts
+++ b/src/modules/85-cv/components/ExecutionVerification/ExecutionVerificationView.utils.ts
@@ -5,14 +5,53 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
+import { HealthSourceV2 } from 'services/cv'
+import { UseStringsReturn } from 'framework/strings'
 import type { ExecutionNode } from 'services/pipeline-ng'
-import type { StringsMap } from 'stringTypes'
+import { LogsProviderType, MetricsProviderType } from './ExecutionVerificationView.constants'
 
 export const getActivityId = (step: ExecutionNode): string => {
   return (step?.outcomes?.output?.activityId || step?.progressData?.activityId) as unknown as string
 }
 
-export const getDefaultTabId = (
-  getString: (key: keyof StringsMap, vars?: Record<string, any> | undefined) => string,
+export const getDefaultTabId = ({
+  getString,
+  canEnableMetricsTab,
+  canEnableLogsTab,
+  tabName
+}: {
+  getString: UseStringsReturn['getString']
   tabName?: string
-): string => (tabName ? tabName : getString('pipeline.verification.analysisTab.metrics'))
+  canEnableMetricsTab: boolean
+  canEnableLogsTab: boolean
+}): string => {
+  if (tabName) {
+    return tabName
+  } else if (canEnableMetricsTab) {
+    return getString('pipeline.verification.analysisTab.metrics')
+  } else if (canEnableLogsTab) {
+    return getString('pipeline.verification.analysisTab.logs')
+  } else {
+    return getString('pipeline.verification.analysisTab.metrics')
+  }
+}
+
+const isHealthSourcesPresent = (healthSources: HealthSourceV2[] | null): healthSources is NonNullable<Array<any>> => {
+  return Boolean(healthSources && Array.isArray(healthSources))
+}
+
+export const getCanEnableMetricsTab = (healthSources: HealthSourceV2[] | null): boolean => {
+  if (!isHealthSourcesPresent(healthSources)) {
+    return false
+  }
+
+  return healthSources.some(healthSource => healthSource.providerType === MetricsProviderType)
+}
+
+export const getCanEnableLogsTab = (healthSources: HealthSourceV2[] | null): boolean => {
+  if (!isHealthSourcesPresent(healthSources)) {
+    return false
+  }
+
+  return healthSources.some(healthSource => healthSource.providerType === LogsProviderType)
+}

--- a/src/modules/85-cv/components/ExecutionVerification/components/DeploymentMetrics/DeploymentMetrics.tsx
+++ b/src/modules/85-cv/components/ExecutionVerification/components/DeploymentMetrics/DeploymentMetrics.tsx
@@ -28,6 +28,7 @@ import cx from 'classnames'
 import { isEqual } from 'lodash-es'
 import { FontVariation, Color } from '@harness/design-system'
 import { useParams } from 'react-router-dom'
+import { GetDataError } from 'restful-react'
 import { useStrings } from 'framework/strings'
 import { useQueryParams } from '@common/hooks'
 import type { ProjectPathProps } from '@common/interfaces/RouteInterfaces'
@@ -35,6 +36,7 @@ import type { ExecutionNode } from 'services/pipeline-ng'
 import {
   AnalysedDeploymentNode,
   GetMetricsAnalysisForVerifyStepExecutionIdQueryParams,
+  HealthSourceV2,
   VerificationOverview,
   useGetHealthSourcesForVerifyStepExecutionId,
   useGetMetricsAnalysisForVerifyStepExecutionId,
@@ -80,6 +82,10 @@ interface DeploymentMetricsProps {
   selectedNode?: AnalysedDeploymentNode
   overviewData: VerificationOverview | null
   overviewLoading?: boolean
+  healthSourcesData: HealthSourceV2[] | null
+  healthSourcesError: GetDataError<unknown> | null
+  healthSourcesLoading: boolean
+  fetchHealthSources: () => Promise<void>
 }
 
 type UpdateViewState = {
@@ -90,7 +96,17 @@ type UpdateViewState = {
 }
 
 export function DeploymentMetrics(props: DeploymentMetricsProps): JSX.Element {
-  const { step, selectedNode, activityId, overviewData, overviewLoading } = props
+  const {
+    step,
+    selectedNode,
+    activityId,
+    overviewData,
+    overviewLoading,
+    fetchHealthSources,
+    healthSourcesData,
+    healthSourcesError,
+    healthSourcesLoading
+  } = props
   const { getString } = useStrings()
   const pageParams = useQueryParams<ExecutionQueryParams>()
 
@@ -176,18 +192,18 @@ export function DeploymentMetrics(props: DeploymentMetricsProps): JSX.Element {
     return getFilterDisplayText(selectedOptions, baseText, getString('all'))
   }, [])
 
-  const {
-    data: healthSourcesData,
-    error: healthSourcesError,
-    loading: healthSourcesLoading,
-    refetch: fetchHealthSources
-  } = useGetHealthSourcesForVerifyStepExecutionId({
-    accountIdentifier: accountId,
-    orgIdentifier,
-    projectIdentifier,
-    verifyStepExecutionId: activityId,
-    lazy: true
-  })
+  // const {
+  //   data: healthSourcesData,
+  //   error: healthSourcesError,
+  //   loading: healthSourcesLoading,
+  //   refetch: fetchHealthSources
+  // } = useGetHealthSourcesForVerifyStepExecutionId({
+  //   accountIdentifier: accountId,
+  //   orgIdentifier,
+  //   projectIdentifier,
+  //   verifyStepExecutionId: activityId,
+  //   lazy: true
+  // })
 
   useEffect(() => {
     if (activityId) {


### PR DESCRIPTION

### Summary

<!-- ✍️ A clear and concise description...-->

#### Screenshots

<img width="1693" alt="image" src="https://github.com/harness/harness-core-ui/assets/95267551/94e647a2-aec8-4d3d-b621-665ff1770d27">

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
