### PR TITLE
feat: [FFM-8947]: event summary missing activity bug fixed

### DIFF
--- a/src/modules/75-cf/components/AuditLogs/EventSummary.module.scss
+++ b/src/modules/75-cf/components/AuditLogs/EventSummary.module.scss
@@ -36,3 +36,9 @@
 .backdrop {
   background-color: rgba(16, 22, 26, 0.4) !important;
 }
+
+.yamlDiffBtn {
+  color: var(--grey-800) !important;
+  font-size: 10px !important;
+  font-weight: 500 !important;
+}

--- a/src/modules/75-cf/components/AuditLogs/EventSummary.module.scss.d.ts
+++ b/src/modules/75-cf/components/AuditLogs/EventSummary.module.scss.d.ts
@@ -12,5 +12,6 @@ declare const styles: {
   readonly container: string
   readonly eventSection: string
   readonly subHeader: string
+  readonly yamlDiffBtn: string
 }
 export default styles

--- a/src/modules/75-cf/components/AuditLogs/EventSummary.tsx
+++ b/src/modules/75-cf/components/AuditLogs/EventSummary.tsx
@@ -167,7 +167,6 @@ export const EventSummary: FC<EventSummaryProps> = ({ data, flagData, onClose })
 
           <Container margin={{ top: 'small' }}>
             <Button
-              data-testId="yaml-diff-btn"
               className={css.yamlDiffBtn}
               minimal
               rightIcon={showDiff ? 'chevron-up' : 'chevron-down'}

--- a/src/modules/75-cf/components/AuditLogs/EventSummary.tsx
+++ b/src/modules/75-cf/components/AuditLogs/EventSummary.tsx
@@ -5,20 +5,20 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { FC, useEffect, useMemo, useState } from 'react'
 import { Drawer, IDrawerProps, Classes } from '@blueprintjs/core'
 import { get } from 'lodash-es'
 import cx from 'classnames'
 import { Layout, Container, Text, Button, useToggle, Heading, PageError } from '@harness/uicore'
-import { Color } from '@harness/design-system'
-import type { MonacoDiffEditorProps } from 'react-monaco-editor'
+import { Color, FontVariation } from '@harness/design-system'
+import { MonacoDiffEditorProps } from 'react-monaco-editor'
 import {
   CF_LOCAL_STORAGE_ENV_KEY,
   DEFAULT_ENV,
   AuditLogAction,
   formatDate,
   formatTime,
-  ADIT_LOG_EMPTY_ENTRY_ID,
+  AUDIT_LOG_EMPTY_ENTRY_ID,
   getErrorMessage
 } from '@cf/utils/CFUtils'
 import MonacoDiffEditor from '@common/components/MonacoDiffEditor/MonacoDiffEditor'
@@ -64,14 +64,15 @@ export interface EventSummaryProps {
   onClose: () => void
 }
 
-export const EventSummary: React.FC<EventSummaryProps> = ({ data, flagData, onClose }) => {
+export const EventSummary: FC<EventSummaryProps> = ({ data, flagData, onClose }) => {
   const { getString } = useStrings()
   const [environment] = useLocalStorage(CF_LOCAL_STORAGE_ENV_KEY, DEFAULT_ENV)
   const { selectedProject } = useAppStore()
   let text = getString('cf.auditLogs.createdMessageFF')
   const [showDiff, toggleShowDiff] = useToggle(false)
   const { objectBefore, objectAfter } = data
-  const isNewObject = objectBefore === ADIT_LOG_EMPTY_ENTRY_ID
+  const isNewObject = objectBefore === AUDIT_LOG_EMPTY_ENTRY_ID
+
   const {
     data: diffData,
     loading,
@@ -84,26 +85,29 @@ export const EventSummary: React.FC<EventSummaryProps> = ({ data, flagData, onCl
   const eventStrings = translateEvents(data.instructionSet, getString)
 
   switch (data.action) {
+    case AuditLogAction.FeatureActivationCreated:
+      text = getString('cf.auditLogs.flagCreated')
+      break
+    case AuditLogAction.FeatureActivationArchived:
+      text = getString('cf.auditLogs.flagArchived')
+      break
+    case AuditLogAction.FeatureActivationRestored:
+      text = getString('cf.auditLogs.flagRestored')
+      break
     case AuditLogAction.SegmentCreated:
-      text = getString('cf.auditLogs.createdMessageSegment')
+      text = getString('cf.auditLogs.segmentCreated')
       break
     case AuditLogAction.FeatureActivationPatched:
-      text = getString('cf.auditLogs.createdMessageFFUpdate')
-      break
-    case AuditLogAction.SegmentPatched:
-      text = getString('cf.auditLogs.updateMessageSegment')
+      text = getString('cf.auditLogs.flagUpdated')
       break
   }
+
   const date = `${formatDate(data.executedOn)}, ${formatTime(data.executedOn)} PST`
+
   const [valueBefore, setValueBefore] = useState<string | undefined>()
   const [valueAfter, setValueAfter] = useState<string | undefined>()
   const [buttonClientY, setButtonClientY] = useState(0)
   const editorHeight = useMemo(() => `calc(100vh - ${buttonClientY + 60}px)`, [buttonClientY])
-  const style = {
-    color: '#22222A',
-    fontWeight: 600,
-    fontSize: '10px'
-  }
 
   useEffect(() => {
     const _before = isNewObject ? undefined : get(diffData, 'data.objectsnapshots[0].value')
@@ -127,7 +131,9 @@ export const EventSummary: React.FC<EventSummaryProps> = ({ data, flagData, onCl
       <Container className={cx(Classes.DRAWER_BODY, css.body)} padding="xlarge">
         <Container className={css.eventSection} padding="large">
           <Layout.Vertical spacing="medium">
-            <Text style={{ fontSize: '14px', fontWeight: 'bold', color: '#9293AB' }}>{date}</Text>
+            <Text color={Color.GREY_400} font={{ variation: FontVariation.H6 }}>
+              {date}
+            </Text>
             <Text color={Color.GREY_400}>
               {getString('cf.auditLogs.summaryHeading', {
                 project: selectedProject?.name,
@@ -143,22 +149,26 @@ export const EventSummary: React.FC<EventSummaryProps> = ({ data, flagData, onCl
             </Text>
           </Container>
 
-          <Container>
-            <Heading level={4} style={{ ...style, padding: 'var(--spacing-xlarge) 0 0 var(--spacing-large)' }}>
-              {getString('cf.auditLogs.changeDetails').toLocaleUpperCase()}
-            </Heading>
-            <ul>
-              {eventStrings.map(message => (
-                <li key={message}>
-                  <Text>{message}</Text>
-                </li>
-              ))}
-            </ul>
-          </Container>
+          <Heading
+            color={Color.GREY_800}
+            level={4}
+            font={{ variation: FontVariation.TINY_SEMI }}
+            style={{ padding: 'var(--spacing-xlarge) 0 0 var(--spacing-large)' }}
+          >
+            {getString('cf.auditLogs.changeDetails').toLocaleUpperCase()}
+          </Heading>
+          <ul>
+            {eventStrings.map(message => (
+              <li key={message}>
+                <Text>{message}</Text>
+              </li>
+            ))}
+          </ul>
 
           <Container margin={{ top: 'small' }}>
             <Button
               data-testId="yaml-diff-btn"
+              className={css.yamlDiffBtn}
               minimal
               rightIcon={showDiff ? 'chevron-up' : 'chevron-down'}
               text={getString('auditTrail.yamlDifference').toLocaleUpperCase()}
@@ -168,7 +178,6 @@ export const EventSummary: React.FC<EventSummaryProps> = ({ data, flagData, onCl
                 toggleShowDiff()
                 refetch()
               }}
-              style={style}
             />
             {showDiff && (
               <Container margin={{ top: 'xsmall', left: 'small', right: 'small' }} height={editorHeight}>

--- a/src/modules/75-cf/components/AuditLogs/__tests__/AuditLogsList.test.tsx
+++ b/src/modules/75-cf/components/AuditLogs/__tests__/AuditLogsList.test.tsx
@@ -273,14 +273,14 @@ describe('AuditLogsList', () => {
 
     expect(await screen.findByRole('heading', { name: 'auditTrail.eventSummary' })).toBeInTheDocument()
     expect(await screen.findByRole('heading', { name: 'CF.AUDITLOGS.CHANGEDETAILS' })).toBeInTheDocument()
-    expect(await screen.findByTestId('yaml-diff-btn')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'AUDITTRAIL.YAMLDIFFERENCE' })).toBeInTheDocument()
 
     await userEvent.click(screen.getByRole('button', { name: 'Close' }))
 
     await waitFor(() => {
       expect(screen.queryByText('auditTrail.eventSummary')).not.toBeInTheDocument()
       expect(screen.queryByText('CF.AUDITLOGS.CHANGEDETAILS')).not.toBeInTheDocument()
-      expect(screen.queryByTestId('yaml-diff-btn')).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'AUDITTRAIL.YAMLDIFFERENCE' })).not.toBeInTheDocument()
     })
   })
 })

--- a/src/modules/75-cf/components/AuditLogs/__tests__/EventSummary.test.tsx
+++ b/src/modules/75-cf/components/AuditLogs/__tests__/EventSummary.test.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+import React from 'react'
+import { screen, render, RenderResult, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { TestWrapper } from '@common/utils/testUtils'
+import mockFeature from '@cf/utils/testData/data/mockFeature'
+import * as cfServices from 'services/cf'
+import { EventSummary, EventSummaryProps } from '../EventSummary'
+import { mockAuditData } from './__data__/mockAuditData'
+import { mockAuditEventActions } from './__data__/mockAuditEventActions'
+
+const renderComponent = (props: Partial<EventSummaryProps> = {}): RenderResult =>
+  render(
+    <TestWrapper>
+      <EventSummary data={mockAuditData.data.auditTrails[0]} flagData={mockFeature} onClose={jest.fn()} {...props} />
+    </TestWrapper>
+  )
+
+describe('EventSummary', () => {
+  const useGetOSByIDMock = jest.spyOn(cfServices, 'useGetOSByID')
+
+  test('it should render the error state correctly', async () => {
+    const message = 'ERROR FETCHING YAML DIFFERENCE'
+    const refetchMock = jest.fn()
+
+    useGetOSByIDMock.mockReturnValue({
+      data: null,
+      loading: false,
+      refetch: refetchMock,
+      error: { message }
+    } as any)
+
+    renderComponent()
+
+    await userEvent.click(screen.getByRole('button', { name: 'AUDITTRAIL.YAMLDIFFERENCE' }))
+
+    expect(await screen.findByText(message)).toBeInTheDocument()
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => expect(refetchMock).toHaveBeenCalled())
+  })
+
+  test('it should render a spinner when loading', async () => {
+    useGetOSByIDMock.mockReturnValue({
+      data: null,
+      loading: true,
+      refetch: jest.fn(),
+      error: null
+    } as any)
+
+    renderComponent()
+
+    await userEvent.click(screen.getByRole('button', { name: 'AUDITTRAIL.YAMLDIFFERENCE' }))
+
+    expect(await screen.findByTestId('page-spinner')).toBeInTheDocument()
+  })
+
+  test.each([
+    ['cf.auditLogs.flagRestored', mockAuditEventActions.data.auditTrails[0]],
+    ['cf.auditLogs.flagArchived', mockAuditEventActions.data.auditTrails[1]],
+    ['cf.auditLogs.flagCreated', mockAuditEventActions.data.auditTrails[2]],
+    ['cf.auditLogs.flagUpdated', mockAuditEventActions.data.auditTrails[3]],
+    ['cf.auditLogs.segmentCreated', mockAuditEventActions.data.auditTrails[4]]
+  ])('it should display %s message for audit action %s', async (userMessage, auditActionType) => {
+    renderComponent({ data: auditActionType })
+
+    expect(screen.getByRole('heading', { name: 'auditTrail.eventSummary' })).toBeInTheDocument()
+
+    expect(await screen.findByText(userMessage)).toBeInTheDocument()
+  })
+})

--- a/src/modules/75-cf/utils/CFUtils.ts
+++ b/src/modules/75-cf/utils/CFUtils.ts
@@ -66,7 +66,7 @@ export enum FeatureFlagMutivariateKind {
 export const CF_LOCAL_STORAGE_ENV_KEY = 'cf_selected_env'
 export const DEFAULT_ENV = { label: '', value: '' }
 export const CF_DEFAULT_PAGE_SIZE = 15
-export const ADIT_LOG_EMPTY_ENTRY_ID = '00000000-0000-0000-0000-000000000000'
+export const AUDIT_LOG_EMPTY_ENTRY_ID = '00000000-0000-0000-0000-000000000000'
 
 export const FeatureFlagActivationStatus = {
   ON: 'on',


### PR DESCRIPTION
This PR adds the missing audit event messages 
e.g. Before: when a flag was archived the audit message would read
<img width="649" alt="image" src="https://github.com/harness/harness-core-ui/assets/95680496/5edf5ccf-b868-48b3-8e39-31f222391262">

After: 
<img width="586" alt="image" src="https://github.com/harness/harness-core-ui/assets/95680496/01613333-1e9a-4ea3-9687-3f69527e8d41">

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
