### PR TITLE
fix: [PL-40612]: tasklist for delegate logs

### DIFF
--- a/src/modules/70-pipeline/components/execution/StepDetails/common/StepDetails/StepDetails.tsx
+++ b/src/modules/70-pipeline/components/execution/StepDetails/common/StepDetails/StepDetails.tsx
@@ -94,10 +94,10 @@ export function StepDetails(props: StepDetailsProps): React.ReactElement {
     return !!delegateList?.find((item: DelegateInfo) => item.taskId === taskId)
   }
 
-  const delegateLogsAvailable =
-    (step.startTs !== undefined && step.delegateInfoList && step.delegateInfoList.length > 0) ||
-    (step.startTs !== undefined && step.stepDetails && Object.keys(step.stepDetails).length > 0)
   const delegateInfoList = !isEmpty(step.delegateInfoList) ? step.delegateInfoList : taskList
+  const delegateLogsAvailable =
+    (step.startTs !== undefined && !isEmpty(delegateInfoList)) ||
+    (step.startTs !== undefined && step.stepDetails && Object.keys(step.stepDetails).length > 0)
   const timePadding = 60 * 5 // 5 minutes
   const taskIds = delegateInfoList?.map(delegate => delegate.taskId || '')?.filter(a => a)
   const startTime = Math.floor((step?.startTs as number) / 1000) - timePadding


### PR DESCRIPTION
### Summary

Delegate info is available in different keys for different step types. 
Earlier, we were reading only `step.delegateInfoList` to check for available tasks. But now we are using the correct object to read the pre-generated tasklist.

#### Screenshots

Before:
<img width="429" alt="Screenshot 2023-08-08 at 11 40 40 AM" src="https://github.com/harness/harness-core-ui/assets/47316575/03470a97-d5f0-4a95-ad9f-de8618aefc2b">

After:
<img width="395" alt="Screenshot 2023-08-08 at 11 40 47 AM" src="https://github.com/harness/harness-core-ui/assets/47316575/919b2b5a-a6bf-45de-a055-35d5260cbc95">


#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
