### PR TITLE
fix: [CDS-76781]: page crash issue in execution page on hover of environment list

### DIFF
--- a/src/modules/75-cd/components/CDExecutionSummary/EnvironmentsList.tsx
+++ b/src/modules/75-cd/components/CDExecutionSummary/EnvironmentsList.tsx
@@ -83,7 +83,7 @@ export function EnvironmentsList({ environments, limit = 2, className }: Environ
                       font={{ variation: FontVariation.FORM_LABEL }}
                       key={index}
                     >
-                      {environment.name}
+                      {defaultTo(environment.name, '')}
                     </Text>
                   ))}
                 </Layout.Vertical>

--- a/src/modules/75-cd/components/CDExecutionSummary/EnvironmentsList.tsx
+++ b/src/modules/75-cd/components/CDExecutionSummary/EnvironmentsList.tsx
@@ -83,7 +83,7 @@ export function EnvironmentsList({ environments, limit = 2, className }: Environ
                       font={{ variation: FontVariation.FORM_LABEL }}
                       key={index}
                     >
-                      {environment}
+                      {environment.name}
                     </Text>
                   ))}
                 </Layout.Vertical>


### PR DESCRIPTION
### Summary

- The environment object DTO was changed from string[] to Environment[] but the display for popover was still rendering complete Environment Object instead of string (environment Name) hence the page crash

#### Screenshots


https://github.com/harness/harness-core-ui/assets/106532291/b90ceee0-dfd8-4a58-97cd-420606cc03f8



#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
