### PR TITLE
fix: [CDS-76892]: use empty string when value/original is falsy to avoid page crash

### DIFF
--- a/src/modules/10-common/components/MonacoDiffEditor/MonacoDiffEditor.tsx
+++ b/src/modules/10-common/components/MonacoDiffEditor/MonacoDiffEditor.tsx
@@ -61,6 +61,8 @@ const MonacoDiffEditor = forwardRef<MonacoDiffEditorRef, ExtendedMonacoDiffEdito
     return (
       <ReactMonacoDiffEditor
         {...props}
+        value={props.value ?? ''}
+        original={props.original ?? ''}
         theme={theme}
         editorWillMount={editorWillMount}
         editorDidMount={editorDidMount}

--- a/src/modules/75-cf/components/AuditLogs/EventSummary.tsx
+++ b/src/modules/75-cf/components/AuditLogs/EventSummary.tsx
@@ -188,24 +188,6 @@ export const EventSummary: FC<EventSummaryProps> = ({ data, flagData, onClose })
                     original={valueBefore}
                     value={valueAfter}
                     options={DIFF_VIEWER_OPTIONS}
-                    editorDidMount={editor => {
-                      setTimeout(() => {
-                        ;(
-                          editor as unknown as {
-                            setSelection: (param: Record<string, number>) => void
-                          }
-                        ).setSelection({
-                          startLineNumber: 0,
-                          startColumn: 0,
-                          endLineNumber: 0,
-                          endColumn: 0,
-                          selectionStartLineNumber: 0,
-                          selectionStartColumn: 0,
-                          positionLineNumber: 0,
-                          positionColumn: 0
-                        })
-                      }, 0)
-                    }}
                   />
                 )}
 


### PR DESCRIPTION
Update `MonacoDiffEditor` to use empty strings for `value` and `original` props if they are falsy. The types exposed by the library are incorrect as `value`, `original` are typed as `string | undefined`, but passing `undefined` throws an error.