### PR TITLE
fix: [CDS-74650]: TagValue new filter scheme handling and fixed page breaks when using :value as tags

### DIFF
--- a/src/modules/10-common/components/Filter/utils/FilterUtils.tsx
+++ b/src/modules/10-common/components/Filter/utils/FilterUtils.tsx
@@ -26,11 +26,11 @@ export const renderItemByType = (data: supportedTypes | Array<supportedTypes> | 
   } else if (typeof data === 'object') {
     if (Object.prototype.hasOwnProperty.call(data, 'key') && Object.prototype.hasOwnProperty.call(data, 'value')) {
       const { key, value } = data as NGTag
-      return key.toString().concat(value ? tagSeparator.concat(value.toString()) : '')
+      return key?.toString().concat(value ? tagSeparator.concat(value.toString()) : '')
     }
     return Object.entries(data)
       .map(([key, value]) => {
-        return key.toString().concat(value ? tagSeparator.concat(value.toString()) : '')
+        return key?.toString().concat(value ? tagSeparator.concat(value.toString()) : '')
       })
       .join(', ')
   } else if (typeof data === 'number') {

--- a/src/modules/10-common/hooks/useQueryParams.ts
+++ b/src/modules/10-common/hooks/useQueryParams.ts
@@ -26,22 +26,24 @@ export function useQueryParams<T = unknown>(options?: UseQueryParamsOptions<T>):
     }
 
     return params
-  }, [search, options, options?.processQueryParams])
+  }, [search, options])
 
   return queryParams as unknown as T
 }
+
+type CustomQsDecoderOptions = {
+  parseNumbers?: boolean
+  parseBoolean?: boolean
+  ignoreNull?: boolean
+  ignoreEmptyString?: boolean
+}
+
+type CustomQsDecoder = (customQsDecoderOptions?: CustomQsDecoderOptions) => IParseOptions['decoder']
 
 /**
  * By default, all values are parsed as strings by qs, except for arrays and objects
  * This is optional decoder that automatically transforms to numbers, booleans and null
  */
-type CustomQsDecoder = (customQsDecoderOptions?: {
-  parseNumbers?: boolean
-  parseBoolean?: boolean
-  ignoreNull?: boolean
-  ignoreEmptyString?: boolean
-}) => IParseOptions['decoder']
-
 export const queryParamDecodeAll: CustomQsDecoder =
   ({ parseNumbers = true, parseBoolean = true, ignoreNull = true, ignoreEmptyString = true } = {}) =>
   (value, decoder) => {
@@ -80,7 +82,8 @@ const ignoreList = ['searchTerm']
 
 // This uses queryParamDecodeAll as the decoder and assigns the value from default params if the processed param's value is null/undefined.
 export const useQueryParamsOptions = <Q extends object, DKey extends keyof Q>(
-  defaultParams: { [K in DKey]: NonNullable<Q[K]> }
+  defaultParams: { [K in DKey]: NonNullable<Q[K]> },
+  decoderOptions?: CustomQsDecoderOptions
 ): UseQueryParamsOptions<RequiredPick<Q, DKey>> => {
   const defaultParamsRef = useRef(defaultParams)
   useEffect(() => {
@@ -89,7 +92,7 @@ export const useQueryParamsOptions = <Q extends object, DKey extends keyof Q>(
 
   const options = useMemo(
     () => ({
-      decoder: queryParamDecodeAll(),
+      decoder: queryParamDecodeAll(decoderOptions),
       processQueryParams: (params: Q) => {
         const processedParams = { ...params }
 

--- a/src/modules/70-pipeline/pages/execution-list/ExecutionListFilter/ExecutionListFilter.tsx
+++ b/src/modules/70-pipeline/pages/execution-list/ExecutionListFilter/ExecutionListFilter.tsx
@@ -283,6 +283,14 @@ export function ExecutionListFilter(): React.ReactElement {
     }
   }
 
+  const pipelineTags = React.useMemo(
+    () =>
+      _pipelineTags?.reduce(
+        (obj, item) => Object.assign(obj, { [item.key]: !isUndefined(item.value) ? item.value : null }),
+        {}
+      ),
+    [_pipelineTags]
+  )
   const reset = () => replaceQueryParams({})
 
   /**End Handlers */
@@ -319,10 +327,7 @@ export function ExecutionListFilter(): React.ReactElement {
         initialFilter={{
           formValues: {
             pipelineName,
-            pipelineTags: _pipelineTags?.reduce(
-              (obj, item) => Object.assign(obj, { [item.key]: !isUndefined(item.value) ? item.value : null }),
-              {}
-            ),
+            pipelineTags,
             repositoryName,
             status: getMultiSelectFormOptions(status),
             branch,

--- a/src/modules/70-pipeline/pages/execution-list/ExecutionListFilter/ExecutionListFilter.tsx
+++ b/src/modules/70-pipeline/pages/execution-list/ExecutionListFilter/ExecutionListFilter.tsx
@@ -11,7 +11,7 @@ import { useParams } from 'react-router-dom'
 import { Layout, SelectOption, useToaster } from '@harness/uicore'
 import * as Yup from 'yup'
 import type { FormikProps } from 'formik'
-import { isEmpty, toLower } from 'lodash-es'
+import { isEmpty, isUndefined, toLower } from 'lodash-es'
 import { useStrings } from 'framework/strings'
 import { useAppStore } from 'framework/AppStore/AppStoreContext'
 import type { FilterDTO, PipelineExecutionFilterProperties } from 'services/pipeline-ng'
@@ -240,7 +240,10 @@ export function ExecutionListFilter(): React.ReactElement {
   const onApply = (inputFormData: FormikProps<PipelineExecutionFormType>['values']) => {
     if (!isObjectEmpty(inputFormData)) {
       const filterFromFormData = getValidFilterArguments({ ...inputFormData }, 'PipelineExecution')
-      updateQueryParams({ page: undefined, filterIdentifier: undefined, filters: filterFromFormData || {} })
+      updateQueryParams(
+        { page: undefined, filterIdentifier: undefined, filters: filterFromFormData || {} },
+        { strictNullHandling: true, skipNulls: false }
+      )
       hideFilterDrawer()
       trackEvent(CDActions.ApplyAdvancedFilter, {
         category: Category.PIPELINE_EXECUTION
@@ -316,7 +319,10 @@ export function ExecutionListFilter(): React.ReactElement {
         initialFilter={{
           formValues: {
             pipelineName,
-            pipelineTags: _pipelineTags?.reduce((obj, item) => Object.assign(obj, { [item.key]: item.value }), {}),
+            pipelineTags: _pipelineTags?.reduce(
+              (obj, item) => Object.assign(obj, { [item.key]: !isUndefined(item.value) ? item.value : null }),
+              {}
+            ),
             repositoryName,
             status: getMultiSelectFormOptions(status),
             branch,

--- a/src/modules/70-pipeline/pages/execution-list/ExecutionListFilterForm/__tests__/ExecutionListFilterForm.test.tsx
+++ b/src/modules/70-pipeline/pages/execution-list/ExecutionListFilterForm/__tests__/ExecutionListFilterForm.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react'
-import { fireEvent, getAllByRole, getByPlaceholderText, getByText, render } from '@testing-library/react'
+import { fireEvent, getAllByRole, getByPlaceholderText, getByText, render, screen } from '@testing-library/react'
 import { act } from 'react-dom/test-utils'
 
 import { Formik, FormikForm } from '@harness/uicore'
@@ -54,6 +54,11 @@ function WrapperComponent(): JSX.Element {
   )
 }
 
+const enterTagValue = (tagInputValues: HTMLElement, value: string): void => {
+  fireEvent.change(tagInputValues, { target: { value } })
+  fireEvent.keyDown(tagInputValues, { key: 'Enter', keyCode: 13 })
+}
+
 describe('<ExecutionListFilterForm /> test', () => {
   test('snapshot testing', () => {
     const { container } = render(<WrapperComponent />)
@@ -84,5 +89,15 @@ describe('<ExecutionListFilterForm /> test', () => {
     })
     const selectedTag = getByText(tagInputValues[0] as HTMLElement, 'Aborted')
     expect(selectedTag).toBeDefined()
+  })
+
+  test('Tag value convert to expected key:value', async () => {
+    const { container } = render(<WrapperComponent />)
+    const tagInputValues = screen.getByPlaceholderText(/Type and press enter to create a tag/)
+
+    //tag should retain true values - specifically for v: and d
+    const testTagValue = ['a:b', ':v', 'v:', 'd']
+    testTagValue.forEach(tagValue => enterTagValue(tagInputValues, tagValue))
+    testTagValue.forEach(tagValue => expect(getByText(container, tagValue)).toBeInTheDocument())
   })
 })

--- a/src/modules/70-pipeline/pages/execution-list/utils/executionListUtil.ts
+++ b/src/modules/70-pipeline/pages/execution-list/utils/executionListUtil.ts
@@ -32,11 +32,17 @@ export const getIsSavedFilterApplied = (filterIdentifier?: string): boolean => {
 export const useExecutionsQueryParamOptions = (): UseQueryParamsOptions<ProcessedExecutionListPageQueryParams> => {
   const { PL_NEW_PAGE_SIZE } = useFeatureFlags()
 
-  return useQueryParamsOptions({
-    page: DEFAULT_PAGE_INDEX,
-    size: PL_NEW_PAGE_SIZE ? COMMON_DEFAULT_PAGE_SIZE : DEFAULT_PAGE_SIZE,
-    sort: DEFAULT_EXECUTION_LIST_TABLE_SORT
-  })
+  const _options = useQueryParamsOptions(
+    {
+      page: DEFAULT_PAGE_INDEX,
+      size: PL_NEW_PAGE_SIZE ? COMMON_DEFAULT_PAGE_SIZE : DEFAULT_PAGE_SIZE,
+      sort: DEFAULT_EXECUTION_LIST_TABLE_SORT
+    },
+    { ignoreEmptyString: false }
+  )
+  const options = useMemo(() => ({ ..._options, strictNullHandling: true }), [_options])
+
+  return options
 }
 
 export const useExecutionListQueryParams = (): ProcessedExecutionListPageQueryParams => {

--- a/src/modules/70-pipeline/pages/pipeline-list/PipelineListFilter/PipelineListFilter.tsx
+++ b/src/modules/70-pipeline/pages/pipeline-list/PipelineListFilter/PipelineListFilter.tsx
@@ -9,7 +9,7 @@
 import React, { useEffect, useMemo, useRef } from 'react'
 import { Layout, SelectOption } from '@harness/uicore'
 import type { FormikProps } from 'formik'
-import { isEmpty } from 'lodash-es'
+import { isEmpty, isUndefined } from 'lodash-es'
 import { useParams } from 'react-router-dom'
 import type { FilterDataInterface, FilterInterface } from '@common/components/Filter/Constants'
 import { Filter, FilterRef } from '@common/components/Filter/Filter'
@@ -200,7 +200,10 @@ export function PipelineListFilter({ onFilterListUpdate }: PipelineListFilterPro
   const onApply = (inputFormData: FormikProps<PipelineFormType>['values']): void => {
     if (!isObjectEmpty(inputFormData)) {
       const filterFromFormData = getValidFilterArguments({ ...inputFormData }, 'PipelineSetup')
-      updateQueryParams({ page: undefined, filterIdentifier: undefined, filters: filterFromFormData || {} })
+      updateQueryParams(
+        { page: undefined, filterIdentifier: undefined, filters: filterFromFormData || {} },
+        { skipNulls: false, strictNullHandling: true }
+      )
       hideFilterDrawer()
       trackEvent(CDActions.ApplyAdvancedFilter, {
         category: Category.PIPELINE
@@ -247,7 +250,10 @@ export function PipelineListFilter({ onFilterListUpdate }: PipelineListFilterPro
   const filterFormValues = useMemo(() => {
     const formValues = {
       name: pipelineName,
-      pipelineTags: _pipelineTags?.reduce((obj, item) => Object.assign(obj, { [item.key]: item.value }), {}),
+      pipelineTags: _pipelineTags?.reduce(
+        (obj, item) => Object.assign(obj, { [item.key]: !isUndefined(item.value) ? item.value : null }),
+        {}
+      ),
       description,
       branch,
       tag,

--- a/src/modules/70-pipeline/pages/pipeline-list/PipelineListFilter/PipelineListFilter.tsx
+++ b/src/modules/70-pipeline/pages/pipeline-list/PipelineListFilter/PipelineListFilter.tsx
@@ -243,6 +243,15 @@ export function PipelineListFilter({ onFilterListUpdate }: PipelineListFilterPro
     }
   }
 
+  const pipelineTags = React.useMemo(
+    () =>
+      _pipelineTags?.reduce(
+        (obj, item) => Object.assign(obj, { [item.key]: !isUndefined(item.value) ? item.value : null }),
+        {}
+      ),
+    [_pipelineTags]
+  )
+
   const reset = () => replaceQueryParams({})
 
   /**End Handlers */
@@ -250,10 +259,7 @@ export function PipelineListFilter({ onFilterListUpdate }: PipelineListFilterPro
   const filterFormValues = useMemo(() => {
     const formValues = {
       name: pipelineName,
-      pipelineTags: _pipelineTags?.reduce(
-        (obj, item) => Object.assign(obj, { [item.key]: !isUndefined(item.value) ? item.value : null }),
-        {}
-      ),
+      pipelineTags,
       description,
       branch,
       tag,

--- a/src/modules/70-pipeline/pages/pipeline-list/PipelineListUtils.ts
+++ b/src/modules/70-pipeline/pages/pipeline-list/PipelineListUtils.ts
@@ -53,11 +53,17 @@ export const getRouteProps = (pathParams: PipelineListPagePathParams, pipeline?:
 export const usePipelinesQueryParamOptions = (): UseQueryParamsOptions<ProcessedPipelineListPageQueryParams> => {
   const { PL_NEW_PAGE_SIZE } = useFeatureFlags()
 
-  return useQueryParamsOptions({
-    page: DEFAULT_PAGE_INDEX,
-    size: PL_NEW_PAGE_SIZE ? COMMON_DEFAULT_PAGE_SIZE : DEFAULT_PAGE_SIZE,
-    sort: DEFAULT_PIPELINE_LIST_TABLE_SORT
-  })
+  const _options = useQueryParamsOptions(
+    {
+      page: DEFAULT_PAGE_INDEX,
+      size: PL_NEW_PAGE_SIZE ? COMMON_DEFAULT_PAGE_SIZE : DEFAULT_PAGE_SIZE,
+      sort: DEFAULT_PIPELINE_LIST_TABLE_SORT
+    },
+    { ignoreEmptyString: false }
+  )
+  const options = useMemo(() => ({ ..._options, strictNullHandling: true }), [_options])
+
+  return options
 }
 
 export const getEmptyStateIllustration = (hasFilter: boolean, module?: Module): string => {

--- a/src/modules/70-pipeline/pages/utils/Filters/filters.ts
+++ b/src/modules/70-pipeline/pages/utils/Filters/filters.ts
@@ -102,7 +102,7 @@ export const useFilterWithValidFieldsWithMetaInfoForTemplates = (
 export const prepareFiltersPayload = (filters: PipelineFilterProperties) => {
   if (filters?.pipelineTags) {
     filters.pipelineTags = filters?.pipelineTags?.map(({ key, value }) => {
-      return { key, value: value ?? '' }
+      return { key, value }
     })
   }
 


### PR DESCRIPTION
### Summary

Added new tag value filter scheme (Only done for pipelines and execution page -

Examples - 
-   :v  ->  key: "", value: "v"
-   v:  ->  key: "v", value: ""
-   a:b ->  key: "a", value: "b"
-   a   ->  key: "a", value: null

Changes in `decoderOptions` and `updateQueryParams` are done to allow them to retain null as a value so that it can be later sent to API as a payload. Main goal here is to retain the actual user-entered value.

Also added a test case to validate if tagValue retain its true value

#### Screenshots

https://github.com/harness/harness-core-ui/assets/98325173/bd3f2165-a345-4978-b7bb-b67cfd6fb911


#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
