### PR TITLE
fix: [CDS-76843]: cannot add multiple artifact sources for ASG Service Spec

### DIFF
--- a/src/modules/70-pipeline/components/ArtifactsSelection/ServiceV2ArtifactsSelection.tsx
+++ b/src/modules/70-pipeline/components/ArtifactsSelection/ServiceV2ArtifactsSelection.tsx
@@ -338,7 +338,7 @@ export default function ServiceV2ArtifactsSelection({
       refetchConnectorList()
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [artifactContext, artifacts, refetchConnectorList, selectedArtifact, stage]
+    [artifactContext, artifacts, refetchConnectorList, selectedArtifact, stage,artifactIndex]
   )
 
   const removeArtifactObject = (type: ModalViewFor, index: number): void => {

--- a/src/modules/70-pipeline/components/ArtifactsSelection/ServiceV2ArtifactsSelection.tsx
+++ b/src/modules/70-pipeline/components/ArtifactsSelection/ServiceV2ArtifactsSelection.tsx
@@ -338,7 +338,7 @@ export default function ServiceV2ArtifactsSelection({
       refetchConnectorList()
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [artifactContext, artifacts, refetchConnectorList, selectedArtifact, stage,artifactIndex]
+    [artifactContext, artifacts, refetchConnectorList, selectedArtifact, stage, artifactIndex]
   )
 
   const removeArtifactObject = (type: ModalViewFor, index: number): void => {


### PR DESCRIPTION
### Summary

Problem :- User cannot add multiple artifact sources for ASG Service Spec 

Solution :- The `artifactIndex` being passed to the `setPrimaryArtifactData` was getting the older value hence was updating an existing value instead of adding to the list. Added artifactIndex in the `useMemo` dependency

#### Screenshots


https://github.com/harness/harness-core-ui/assets/106532291/14dc7e54-a857-4723-926e-05f9a37fb655



#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
