### PR TITLE
feat: [PL-38949]: Secrets in child scope using parent SecretManager

### DIFF
--- a/cypress/integration/75-cd/EnvironmentConfiguration.spec.ts
+++ b/cypress/integration/75-cd/EnvironmentConfiguration.spec.ts
@@ -120,7 +120,7 @@ describe('EnvironmentsV2 Configuration Page', () => {
 
     cy.wait('@envSecretCall')
 
-    cy.contains('p', 'Id: secretId.harnessSecretManager').should('be.visible').click()
+    cy.contains('p', 'Id: secretId').should('be.visible').click()
     cy.get('span[data-icon="pipeline-approval"]').should('be.visible') // Approval Icon visible
     cy.contains('button[type="button"]', 'Apply Selected').should('be.visible').click()
 

--- a/cypress/integration/75-cd/EnvironmentConfiguration.spec.ts
+++ b/cypress/integration/75-cd/EnvironmentConfiguration.spec.ts
@@ -158,7 +158,7 @@ describe('EnvironmentsV2 Configuration Page', () => {
     cy.get('button[data-testid="create-or-select-secret"]').eq(1).should('not.be.disabled').click()
     cy.wait('@envSecretCall', { timeout: 10000 })
 
-    cy.contains('p', 'Id: secretId.harnessSecretManager').should('be.visible').click()
+    cy.contains('p', 'Id: secretId').should('be.visible').click()
     cy.get('span[data-icon="pipeline-approval"]').should('be.visible') // Approval Icon visible
     cy.contains('button[type="button"]', 'Apply Selected').should('be.visible').click()
     cy.get('button[data-testid="delete-variable-4"]').should('be.visible').click() // Deleting var5

--- a/src/modules/27-platform/connectors/components/ConnectorReferenceField/ConnectorReferenceField.tsx
+++ b/src/modules/27-platform/connectors/components/ConnectorReferenceField/ConnectorReferenceField.tsx
@@ -145,6 +145,7 @@ export interface ConnectorReferenceFieldProps extends Omit<IFormGroupProps, 'lab
   onMultiSelectChange?: (arg: ScopeAndIdentifier[]) => void
   isRecordDisabled?: (val?: any) => boolean
   renderRecordDisabledWarning?: JSX.Element
+  componentName?: string
 }
 
 export interface ConnectorReferenceDTO extends ConnectorInfoDTO {
@@ -478,6 +479,7 @@ export function getReferenceFieldProps({
   selectedConnectors,
   isRecordDisabled,
   renderRecordDisabledWarning,
+  componentName,
   isFavoritesEnabled
 }: GetReferenceFieldMethodProps): Omit<
   ReferenceSelectProps<ConnectorReferenceDTO>,
@@ -490,7 +492,7 @@ export function getReferenceFieldProps({
     selected,
     placeholder,
     defaultScope,
-    createNewLabel: getString('newConnector'),
+    createNewLabel: componentName || getString('newConnector'),
     // recordClassName: css.listItem,
     isNewConnectorLabelVisible: true,
     fetchRecords: (done, search, page, scope, signal = undefined, allTabSelected, sortMethod, favorite) => {
@@ -661,6 +663,7 @@ export const ConnectorReferenceField: React.FC<ConnectorReferenceFieldProps> = p
     onMultiSelectChange,
     isRecordDisabled,
     renderRecordDisabledWarning,
+    componentName,
     ...rest
   } = props
 
@@ -890,6 +893,7 @@ export const ConnectorReferenceField: React.FC<ConnectorReferenceFieldProps> = p
     selectedConnectors,
     isRecordDisabled,
     renderRecordDisabledWarning,
+    componentName,
     isFavoritesEnabled: PL_FAVORITES
   })
 
@@ -923,7 +927,7 @@ export const ConnectorReferenceField: React.FC<ConnectorReferenceFieldProps> = p
               }
             : undefined
         }
-        componentName="Connector"
+        componentName={componentName || getString('connector')}
         noDataCard={{ image: ConnectorsEmptyState }}
         pagination={{
           itemCount: pagedConnectorData?.data?.totalItems || 0,

--- a/src/modules/27-platform/connectors/components/ConnectorReferenceField/ConnectorReferenceField.tsx
+++ b/src/modules/27-platform/connectors/components/ConnectorReferenceField/ConnectorReferenceField.tsx
@@ -1036,3 +1036,5 @@ export const DefaultSettingConnectorField: React.FC<SettingRendererProps & { typ
       />
     )
   }
+
+export default ConnectorReferenceField

--- a/src/modules/27-platform/secrets/components/CreateOrSelectSecret/__tests__/__snapshots__/CreateOrSelectSecret.test.tsx.snap
+++ b/src/modules/27-platform/secrets/components/CreateOrSelectSecret/__tests__/__snapshots__/CreateOrSelectSecret.test.tsx.snap
@@ -206,7 +206,7 @@ exports[`CreateOrSelectSecret render 1`] = `
                                     class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--font-size-small StyledProps--font-weight-light StyledProps--color StyledProps--color-grey600"
                                     style="--text-line-clamp: 1;"
                                   >
-                                    common.ID: a1.harnessSecretManager
+                                    common.ID: a1
                                   </p>
                                 </div>
                               </div>
@@ -350,7 +350,7 @@ exports[`CreateOrSelectSecret render 1`] = `
                                     class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--font-size-small StyledProps--font-weight-light StyledProps--color StyledProps--color-grey600"
                                     style="--text-line-clamp: 1;"
                                   >
-                                    common.ID: demo1.harnessSecretManager
+                                    common.ID: demo1
                                   </p>
                                 </div>
                               </div>
@@ -494,7 +494,7 @@ exports[`CreateOrSelectSecret render 1`] = `
                                     class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--font-size-small StyledProps--font-weight-light StyledProps--color StyledProps--color-grey600"
                                     style="--text-line-clamp: 1;"
                                   >
-                                    common.ID: text1.vault1
+                                    common.ID: text1
                                   </p>
                                 </div>
                               </div>

--- a/src/modules/27-platform/secrets/components/CreateOrSelectSecret/__tests__/secretsListMockData.json
+++ b/src/modules/27-platform/secrets/components/CreateOrSelectSecret/__tests__/secretsListMockData.json
@@ -14,7 +14,7 @@
           "tags": {},
           "description": "",
           "spec": {
-            "secretManagerIdentifier": "harnessSecretManager",
+            "secretManagerIdentifier": "account.harnessSecretManager",
             "valueType": "Inline",
             "value": null
           }

--- a/src/modules/27-platform/secrets/components/CreateUpdateSecret/CreateUpdateSecret.tsx
+++ b/src/modules/27-platform/secrets/components/CreateUpdateSecret/CreateUpdateSecret.tsx
@@ -106,10 +106,9 @@ const CreateUpdateSecret: React.FC<CreateUpdateSecretProps> = props => {
   const secretTypeFromProps = props.type
   const [type, setType] = useState<SecretResponseWrapper['secret']['type']>(secretTypeFromProps || 'SecretText')
   const [secret, setSecret] = useState<SecretDTOV2>()
-  const [searchTerm /*setSearchTerm*/] = useState<string>('')
+  const [searchTerm] = useState<string>('')
   const [initialSecretManagerAPICallInProgress, setInitialSecretManagerAPICallInProgress] = useState(true)
-  // const [initialSecretManagerChangedOrSearchStared, setInitialSecretManagerChangedOrSearchStared] =
-  //   useState<boolean>(false)
+
   const { conditionallyOpenGovernanceErrorModal } = useGovernanceMetaDataModal({
     considerWarningAsError: false,
     errorHeaderMsg: 'platform.secrets.policyEvaluations.failedToSave',
@@ -590,43 +589,6 @@ const CreateUpdateSecret: React.FC<CreateUpdateSecretProps> = props => {
                     }}
                   />
                 </Suspense>
-
-                {/* <FormInput.Select
-                  onQueryChange={(query: string) => {
-                    if (!initialSecretManagerChangedOrSearchStared) {
-                      setInitialSecretManagerChangedOrSearchStared(true)
-                    }
-                    setSearchTerm(query)
-                  }}
-                  name="secretManagerIdentifier"
-                  label={getString('platform.secrets.labelSecretsManager')}
-                  items={secretManagersOptions}
-                  disabled={editing || loadingSecretsManagers || loadingConnectorDetails}
-                  onChange={item => {
-                    if (!initialSecretManagerChangedOrSearchStared) {
-                      setInitialSecretManagerChangedOrSearchStared(true)
-                    }
-                    const secretManagerData = secretManagersApiResponse?.data?.content?.find(
-                      itemValue => itemValue.connector?.identifier === item.value
-                    )?.connector
-                    const readOnlyTemp =
-                      secretManagerData?.type === 'Vault'
-                        ? (secretManagerData?.spec as VaultConnectorDTO)?.readOnly
-                        : false
-                    setReadOnlySecretManager(readOnlyTemp)
-                    formikProps.setFieldValue(
-                      'valueType',
-                      secretManagerData?.type === 'CustomSecretManager'
-                        ? 'CustomSecretManagerValues'
-                        : readOnlyTemp
-                        ? 'Reference'
-                        : 'Inline'
-                    )
-
-                    initializeTemplateInputs(secretManagerData)
-                    setSelectedSecretManager(secretManagerData)
-                  }}
-                /> */}
 
                 {!secretTypeFromProps ? (
                   <FormInput.RadioGroup

--- a/src/modules/27-platform/secrets/components/CreateUpdateSecret/__tests__/__snapshots__/CreateUpdateSecret.test.tsx.snap
+++ b/src/modules/27-platform/secrets/components/CreateUpdateSecret/__tests__/__snapshots__/CreateUpdateSecret.test.tsx.snap
@@ -12,11 +12,10 @@ exports[`CreateUpdateSecret Create File Secret 1`] = `
       <div>
         <div
           class="bp3-form-group"
-          data-id="secretManagerIdentifier-0"
+          data-id="null-0"
         >
           <label
             class="bp3-label"
-            for="secretManagerIdentifier"
           >
             <span
               class="Tooltip--acenter"
@@ -32,50 +31,92 @@ exports[`CreateUpdateSecret Create File Secret 1`] = `
           <div
             class="bp3-form-content"
           >
-            <div
-              class="bp3-popover-wrapper Select--main bp3-fill"
+            <button
+              class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main container Button--iconOnly Button--without-shadow Button--withRightIcon"
+              data-testid="cr-field-secretManagerIdentifier"
+              style="width: 100%;"
+              type="button"
             >
-              <div
-                class="bp3-popover-target"
+              <span
+                class="bp3-button-text"
               >
                 <div
-                  class="bp3-input-group"
+                  class="Layout--horizontal Layout--layout-spacing-small StyledProps--main selectWrapper StyledProps--flex StyledProps--flex-distribution-space-between"
                 >
-                  <input
-                    autocomplete="off"
-                    class="bp3-input"
-                    name="secretManagerIdentifier"
-                    placeholder="- Select -"
-                    style="padding-right: 0px;"
-                    type="text"
-                    value="Harness Secrets Manager"
-                  />
                   <span
-                    class="bp3-input-action"
+                    class="bp3-popover-wrapper"
                   >
                     <span
-                      class="bp3-icon bp3-icon-chevron-down StyledProps--main StyledProps--padding-small"
-                      icon="chevron-down"
+                      class="bp3-popover-target Text--targetClass"
+                    >
+                      <p
+                        class="StyledProps--font StyledProps--main label StyledProps--color StyledProps--color-grey800"
+                        tabindex="0"
+                      >
+                        vault1
+                      </p>
+                    </span>
+                  </span>
+                  <div
+                    class="rightStatus"
+                  >
+                    <span
+                      class="bp3-icon bp3-icon-full-circle StyledProps--main status greenStatus"
+                      data-testid="crf-status"
+                      icon="full-circle"
                     >
                       <svg
-                        data-icon="chevron-down"
-                        height="14"
+                        data-icon="full-circle"
+                        height="6"
                         viewBox="0 0 16 16"
-                        width="14"
+                        width="6"
                       >
                         <desc>
-                          chevron-down
+                          full-circle
                         </desc>
                         <path
-                          d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                          d="M8 0a8 8 0 100 16A8 8 0 108 0z"
                           fill-rule="evenodd"
                         />
                       </svg>
                     </span>
-                  </span>
+                    <span
+                      class="Tag--main"
+                    >
+                      <span
+                        class="bp3-tag bp3-minimal"
+                        id="tag"
+                      >
+                        <span
+                          class="bp3-text-overflow-ellipsis bp3-fill"
+                        >
+                          account
+                        </span>
+                      </span>
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </div>
+              </span>
+              <span
+                class="bp3-icon bp3-icon-chevron-down StyledProps--main"
+                icon="chevron-down"
+              >
+                <svg
+                  data-icon="chevron-down"
+                  height="14"
+                  viewBox="0 0 16 16"
+                  width="14"
+                >
+                  <desc>
+                    chevron-down
+                  </desc>
+                  <path
+                    d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </button>
           </div>
         </div>
         <span
@@ -328,11 +369,10 @@ exports[`CreateUpdateSecret Create Secret with radio button 1`] = `
       <div>
         <div
           class="bp3-form-group"
-          data-id="secretManagerIdentifier-0"
+          data-id="null-0"
         >
           <label
             class="bp3-label"
-            for="secretManagerIdentifier"
           >
             <span
               class="Tooltip--acenter"
@@ -348,50 +388,92 @@ exports[`CreateUpdateSecret Create Secret with radio button 1`] = `
           <div
             class="bp3-form-content"
           >
-            <div
-              class="bp3-popover-wrapper Select--main bp3-fill"
+            <button
+              class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main container Button--iconOnly Button--without-shadow Button--withRightIcon"
+              data-testid="cr-field-secretManagerIdentifier"
+              style="width: 100%;"
+              type="button"
             >
-              <div
-                class="bp3-popover-target"
+              <span
+                class="bp3-button-text"
               >
                 <div
-                  class="bp3-input-group"
+                  class="Layout--horizontal Layout--layout-spacing-small StyledProps--main selectWrapper StyledProps--flex StyledProps--flex-distribution-space-between"
                 >
-                  <input
-                    autocomplete="off"
-                    class="bp3-input"
-                    name="secretManagerIdentifier"
-                    placeholder="- Select -"
-                    style="padding-right: 0px;"
-                    type="text"
-                    value="Harness Secrets Manager"
-                  />
                   <span
-                    class="bp3-input-action"
+                    class="bp3-popover-wrapper"
                   >
                     <span
-                      class="bp3-icon bp3-icon-chevron-down StyledProps--main StyledProps--padding-small"
-                      icon="chevron-down"
+                      class="bp3-popover-target Text--targetClass"
+                    >
+                      <p
+                        class="StyledProps--font StyledProps--main label StyledProps--color StyledProps--color-grey800"
+                        tabindex="0"
+                      >
+                        vault1
+                      </p>
+                    </span>
+                  </span>
+                  <div
+                    class="rightStatus"
+                  >
+                    <span
+                      class="bp3-icon bp3-icon-full-circle StyledProps--main status greenStatus"
+                      data-testid="crf-status"
+                      icon="full-circle"
                     >
                       <svg
-                        data-icon="chevron-down"
-                        height="14"
+                        data-icon="full-circle"
+                        height="6"
                         viewBox="0 0 16 16"
-                        width="14"
+                        width="6"
                       >
                         <desc>
-                          chevron-down
+                          full-circle
                         </desc>
                         <path
-                          d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                          d="M8 0a8 8 0 100 16A8 8 0 108 0z"
                           fill-rule="evenodd"
                         />
                       </svg>
                     </span>
-                  </span>
+                    <span
+                      class="Tag--main"
+                    >
+                      <span
+                        class="bp3-tag bp3-minimal"
+                        id="tag"
+                      >
+                        <span
+                          class="bp3-text-overflow-ellipsis bp3-fill"
+                        >
+                          account
+                        </span>
+                      </span>
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </div>
+              </span>
+              <span
+                class="bp3-icon bp3-icon-chevron-down StyledProps--main"
+                icon="chevron-down"
+              >
+                <svg
+                  data-icon="chevron-down"
+                  height="14"
+                  viewBox="0 0 16 16"
+                  width="14"
+                >
+                  <desc>
+                    chevron-down
+                  </desc>
+                  <path
+                    d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </button>
           </div>
         </div>
         <div
@@ -703,11 +785,10 @@ exports[`CreateUpdateSecret Create Secret with radio button and switch radio fro
       <div>
         <div
           class="bp3-form-group"
-          data-id="secretManagerIdentifier-0"
+          data-id="null-0"
         >
           <label
             class="bp3-label"
-            for="secretManagerIdentifier"
           >
             <span
               class="Tooltip--acenter"
@@ -723,50 +804,92 @@ exports[`CreateUpdateSecret Create Secret with radio button and switch radio fro
           <div
             class="bp3-form-content"
           >
-            <div
-              class="bp3-popover-wrapper Select--main bp3-fill"
+            <button
+              class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main container Button--iconOnly Button--without-shadow Button--withRightIcon"
+              data-testid="cr-field-secretManagerIdentifier"
+              style="width: 100%;"
+              type="button"
             >
-              <div
-                class="bp3-popover-target"
+              <span
+                class="bp3-button-text"
               >
                 <div
-                  class="bp3-input-group"
+                  class="Layout--horizontal Layout--layout-spacing-small StyledProps--main selectWrapper StyledProps--flex StyledProps--flex-distribution-space-between"
                 >
-                  <input
-                    autocomplete="off"
-                    class="bp3-input"
-                    name="secretManagerIdentifier"
-                    placeholder="- Select -"
-                    style="padding-right: 0px;"
-                    type="text"
-                    value="Harness Secrets Manager"
-                  />
                   <span
-                    class="bp3-input-action"
+                    class="bp3-popover-wrapper"
                   >
                     <span
-                      class="bp3-icon bp3-icon-chevron-down StyledProps--main StyledProps--padding-small"
-                      icon="chevron-down"
+                      class="bp3-popover-target Text--targetClass"
+                    >
+                      <p
+                        class="StyledProps--font StyledProps--main label StyledProps--color StyledProps--color-grey800"
+                        tabindex="0"
+                      >
+                        vault1
+                      </p>
+                    </span>
+                  </span>
+                  <div
+                    class="rightStatus"
+                  >
+                    <span
+                      class="bp3-icon bp3-icon-full-circle StyledProps--main status greenStatus"
+                      data-testid="crf-status"
+                      icon="full-circle"
                     >
                       <svg
-                        data-icon="chevron-down"
-                        height="14"
+                        data-icon="full-circle"
+                        height="6"
                         viewBox="0 0 16 16"
-                        width="14"
+                        width="6"
                       >
                         <desc>
-                          chevron-down
+                          full-circle
                         </desc>
                         <path
-                          d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                          d="M8 0a8 8 0 100 16A8 8 0 108 0z"
                           fill-rule="evenodd"
                         />
                       </svg>
                     </span>
-                  </span>
+                    <span
+                      class="Tag--main"
+                    >
+                      <span
+                        class="bp3-tag bp3-minimal"
+                        id="tag"
+                      >
+                        <span
+                          class="bp3-text-overflow-ellipsis bp3-fill"
+                        >
+                          account
+                        </span>
+                      </span>
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </div>
+              </span>
+              <span
+                class="bp3-icon bp3-icon-chevron-down StyledProps--main"
+                icon="chevron-down"
+              >
+                <svg
+                  data-icon="chevron-down"
+                  height="14"
+                  viewBox="0 0 16 16"
+                  width="14"
+                >
+                  <desc>
+                    chevron-down
+                  </desc>
+                  <path
+                    d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </button>
           </div>
         </div>
         <div
@@ -1081,11 +1204,10 @@ exports[`CreateUpdateSecret Create Secret with radio button and switch radio fro
       <div>
         <div
           class="bp3-form-group"
-          data-id="secretManagerIdentifier-0"
+          data-id="null-0"
         >
           <label
             class="bp3-label"
-            for="secretManagerIdentifier"
           >
             <span
               class="Tooltip--acenter"
@@ -1101,50 +1223,92 @@ exports[`CreateUpdateSecret Create Secret with radio button and switch radio fro
           <div
             class="bp3-form-content"
           >
-            <div
-              class="bp3-popover-wrapper Select--main bp3-fill"
+            <button
+              class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main container Button--iconOnly Button--without-shadow Button--withRightIcon"
+              data-testid="cr-field-secretManagerIdentifier"
+              style="width: 100%;"
+              type="button"
             >
-              <div
-                class="bp3-popover-target"
+              <span
+                class="bp3-button-text"
               >
                 <div
-                  class="bp3-input-group"
+                  class="Layout--horizontal Layout--layout-spacing-small StyledProps--main selectWrapper StyledProps--flex StyledProps--flex-distribution-space-between"
                 >
-                  <input
-                    autocomplete="off"
-                    class="bp3-input"
-                    name="secretManagerIdentifier"
-                    placeholder="- Select -"
-                    style="padding-right: 0px;"
-                    type="text"
-                    value="Harness Secrets Manager"
-                  />
                   <span
-                    class="bp3-input-action"
+                    class="bp3-popover-wrapper"
                   >
                     <span
-                      class="bp3-icon bp3-icon-chevron-down StyledProps--main StyledProps--padding-small"
-                      icon="chevron-down"
+                      class="bp3-popover-target Text--targetClass"
+                    >
+                      <p
+                        class="StyledProps--font StyledProps--main label StyledProps--color StyledProps--color-grey800"
+                        tabindex="0"
+                      >
+                        vault1
+                      </p>
+                    </span>
+                  </span>
+                  <div
+                    class="rightStatus"
+                  >
+                    <span
+                      class="bp3-icon bp3-icon-full-circle StyledProps--main status greenStatus"
+                      data-testid="crf-status"
+                      icon="full-circle"
                     >
                       <svg
-                        data-icon="chevron-down"
-                        height="14"
+                        data-icon="full-circle"
+                        height="6"
                         viewBox="0 0 16 16"
-                        width="14"
+                        width="6"
                       >
                         <desc>
-                          chevron-down
+                          full-circle
                         </desc>
                         <path
-                          d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                          d="M8 0a8 8 0 100 16A8 8 0 108 0z"
                           fill-rule="evenodd"
                         />
                       </svg>
                     </span>
-                  </span>
+                    <span
+                      class="Tag--main"
+                    >
+                      <span
+                        class="bp3-tag bp3-minimal"
+                        id="tag"
+                      >
+                        <span
+                          class="bp3-text-overflow-ellipsis bp3-fill"
+                        >
+                          account
+                        </span>
+                      </span>
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </div>
+              </span>
+              <span
+                class="bp3-icon bp3-icon-chevron-down StyledProps--main"
+                icon="chevron-down"
+              >
+                <svg
+                  data-icon="chevron-down"
+                  height="14"
+                  viewBox="0 0 16 16"
+                  width="14"
+                >
+                  <desc>
+                    chevron-down
+                  </desc>
+                  <path
+                    d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </button>
           </div>
         </div>
         <div
@@ -1456,11 +1620,9 @@ exports[`CreateUpdateSecret Create Text Secret 1`] = `
       <div>
         <div
           class="bp3-form-group"
-          data-id="secretManagerIdentifier-0"
         >
           <label
             class="bp3-label"
-            for="secretManagerIdentifier"
           >
             <span
               class="Tooltip--acenter"
@@ -1476,50 +1638,92 @@ exports[`CreateUpdateSecret Create Text Secret 1`] = `
           <div
             class="bp3-form-content"
           >
-            <div
-              class="bp3-popover-wrapper Select--main bp3-fill"
+            <button
+              class="bp3-button bp3-minimal Button--button StyledProps--font StyledProps--main container Button--iconOnly Button--without-shadow Button--withRightIcon"
+              data-testid="cr-field-secretManagerIdentifier"
+              style="width: 100%;"
+              type="button"
             >
-              <div
-                class="bp3-popover-target"
+              <span
+                class="bp3-button-text"
               >
                 <div
-                  class="bp3-input-group"
+                  class="Layout--horizontal Layout--layout-spacing-small StyledProps--main selectWrapper StyledProps--flex StyledProps--flex-distribution-space-between"
                 >
-                  <input
-                    autocomplete="off"
-                    class="bp3-input"
-                    name="secretManagerIdentifier"
-                    placeholder="- Select -"
-                    style="padding-right: 0px;"
-                    type="text"
-                    value="Harness Secrets Manager"
-                  />
                   <span
-                    class="bp3-input-action"
+                    class="bp3-popover-wrapper"
                   >
                     <span
-                      class="bp3-icon bp3-icon-chevron-down StyledProps--main StyledProps--padding-small"
-                      icon="chevron-down"
+                      class="bp3-popover-target Text--targetClass"
+                    >
+                      <p
+                        class="StyledProps--font StyledProps--main label StyledProps--color StyledProps--color-grey800"
+                        tabindex="0"
+                      >
+                        vault1
+                      </p>
+                    </span>
+                  </span>
+                  <div
+                    class="rightStatus"
+                  >
+                    <span
+                      class="bp3-icon bp3-icon-full-circle StyledProps--main status greenStatus"
+                      data-testid="crf-status"
+                      icon="full-circle"
                     >
                       <svg
-                        data-icon="chevron-down"
-                        height="14"
+                        data-icon="full-circle"
+                        height="6"
                         viewBox="0 0 16 16"
-                        width="14"
+                        width="6"
                       >
                         <desc>
-                          chevron-down
+                          full-circle
                         </desc>
                         <path
-                          d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                          d="M8 0a8 8 0 100 16A8 8 0 108 0z"
                           fill-rule="evenodd"
                         />
                       </svg>
                     </span>
-                  </span>
+                    <span
+                      class="Tag--main"
+                    >
+                      <span
+                        class="bp3-tag bp3-minimal"
+                        id="tag"
+                      >
+                        <span
+                          class="bp3-text-overflow-ellipsis bp3-fill"
+                        >
+                          account
+                        </span>
+                      </span>
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </div>
+              </span>
+              <span
+                class="bp3-icon bp3-icon-chevron-down StyledProps--main"
+                icon="chevron-down"
+              >
+                <svg
+                  data-icon="chevron-down"
+                  height="14"
+                  viewBox="0 0 16 16"
+                  width="14"
+                >
+                  <desc>
+                    chevron-down
+                  </desc>
+                  <path
+                    d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </button>
           </div>
         </div>
         <span
@@ -1595,7 +1799,7 @@ exports[`CreateUpdateSecret Create Text Secret 1`] = `
               </div>
               <div
                 class="bp3-form-group"
-                data-id="name-1"
+                data-id="name-0"
               >
                 <label
                   class="bp3-label"
@@ -1769,11 +1973,10 @@ exports[`CreateUpdateSecret Update Text Secret 1`] = `
       <div>
         <div
           class="bp3-form-group bp3-disabled"
-          data-id="secretManagerIdentifier-0"
+          data-id="null-0"
         >
           <label
             class="bp3-label"
-            for="secretManagerIdentifier"
           >
             <span
               class="Tooltip--acenter"
@@ -1789,51 +1992,94 @@ exports[`CreateUpdateSecret Update Text Secret 1`] = `
           <div
             class="bp3-form-content"
           >
-            <div
-              class="bp3-popover-wrapper Select--main bp3-fill"
+            <button
+              class="bp3-button bp3-disabled bp3-minimal Button--button StyledProps--font StyledProps--main container Button--iconOnly Button--without-shadow Button--withRightIcon"
+              data-testid="cr-field-secretManagerIdentifier"
+              disabled=""
+              style="width: 100%;"
+              tabindex="-1"
+              type="button"
             >
-              <div
-                class="bp3-popover-target"
+              <span
+                class="bp3-button-text"
               >
                 <div
-                  class="bp3-input-group bp3-disabled"
+                  class="Layout--horizontal Layout--layout-spacing-small StyledProps--main selectWrapper StyledProps--flex StyledProps--flex-distribution-space-between"
                 >
-                  <input
-                    autocomplete="off"
-                    class="bp3-input"
-                    disabled=""
-                    name="secretManagerIdentifier"
-                    placeholder="- Select -"
-                    style="padding-right: 0px;"
-                    type="text"
-                    value="vault1"
-                  />
                   <span
-                    class="bp3-input-action"
+                    class="bp3-popover-wrapper"
                   >
                     <span
-                      class="bp3-icon bp3-icon-chevron-down StyledProps--main StyledProps--padding-small"
-                      icon="chevron-down"
+                      class="bp3-popover-target Text--targetClass"
+                    >
+                      <p
+                        class="StyledProps--font StyledProps--main label StyledProps--color StyledProps--color-grey800"
+                        tabindex="0"
+                      >
+                        vault1
+                      </p>
+                    </span>
+                  </span>
+                  <div
+                    class="rightStatus"
+                  >
+                    <span
+                      class="bp3-icon bp3-icon-full-circle StyledProps--main status greenStatus"
+                      data-testid="crf-status"
+                      icon="full-circle"
                     >
                       <svg
-                        data-icon="chevron-down"
-                        height="14"
+                        data-icon="full-circle"
+                        height="6"
                         viewBox="0 0 16 16"
-                        width="14"
+                        width="6"
                       >
                         <desc>
-                          chevron-down
+                          full-circle
                         </desc>
                         <path
-                          d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                          d="M8 0a8 8 0 100 16A8 8 0 108 0z"
                           fill-rule="evenodd"
                         />
                       </svg>
                     </span>
-                  </span>
+                    <span
+                      class="Tag--main"
+                    >
+                      <span
+                        class="bp3-tag bp3-minimal"
+                        id="tag"
+                      >
+                        <span
+                          class="bp3-text-overflow-ellipsis bp3-fill"
+                        >
+                          project
+                        </span>
+                      </span>
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </div>
+              </span>
+              <span
+                class="bp3-icon bp3-icon-chevron-down StyledProps--main"
+                icon="chevron-down"
+              >
+                <svg
+                  data-icon="chevron-down"
+                  height="14"
+                  viewBox="0 0 16 16"
+                  width="14"
+                >
+                  <desc>
+                    chevron-down
+                  </desc>
+                  <path
+                    d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </button>
           </div>
         </div>
         <span
@@ -1961,7 +2207,6 @@ exports[`CreateUpdateSecret Update Text Secret 1`] = `
         </span>
         <div
           class="bp3-form-group"
-          data-id="value-2"
         >
           <label
             class="bp3-label"
@@ -1997,7 +2242,6 @@ exports[`CreateUpdateSecret Update Text Secret 1`] = `
         </div>
         <div
           class="bp3-form-group"
-          data-id="description-3"
         >
           <label
             class="bp3-label"
@@ -2027,7 +2271,6 @@ exports[`CreateUpdateSecret Update Text Secret 1`] = `
         </div>
         <div
           class="bp3-form-group"
-          data-id="tags-4"
         >
           <label
             class="bp3-label"

--- a/src/modules/27-platform/secrets/components/CreateUpdateSecret/__tests__/__snapshots__/CreateUpdateSecretGCPSecret.test.tsx.snap
+++ b/src/modules/27-platform/secrets/components/CreateUpdateSecret/__tests__/__snapshots__/CreateUpdateSecretGCPSecret.test.tsx.snap
@@ -12,11 +12,9 @@ exports[`CreateUpdateSecret GCP Secret manager Text Secret in GCP 1`] = `
       <div>
         <div
           class="bp3-form-group bp3-disabled"
-          data-id="secretManagerIdentifier-0"
         >
           <label
             class="bp3-label"
-            for="secretManagerIdentifier"
           >
             <span
               class="Tooltip--acenter"
@@ -32,51 +30,94 @@ exports[`CreateUpdateSecret GCP Secret manager Text Secret in GCP 1`] = `
           <div
             class="bp3-form-content"
           >
-            <div
-              class="bp3-popover-wrapper Select--main bp3-fill"
+            <button
+              class="bp3-button bp3-disabled bp3-minimal Button--button StyledProps--font StyledProps--main container Button--iconOnly Button--without-shadow Button--withRightIcon"
+              data-testid="cr-field-secretManagerIdentifier"
+              disabled=""
+              style="width: 100%;"
+              tabindex="-1"
+              type="button"
             >
-              <div
-                class="bp3-popover-target"
+              <span
+                class="bp3-button-text"
               >
                 <div
-                  class="bp3-input-group bp3-disabled"
+                  class="Layout--horizontal Layout--layout-spacing-small StyledProps--main selectWrapper StyledProps--flex StyledProps--flex-distribution-space-between"
                 >
-                  <input
-                    autocomplete="off"
-                    class="bp3-input"
-                    disabled=""
-                    name="secretManagerIdentifier"
-                    placeholder="- Select -"
-                    style="padding-right: 0px;"
-                    type="text"
-                    value="swaraj gcp"
-                  />
                   <span
-                    class="bp3-input-action"
+                    class="bp3-popover-wrapper"
                   >
                     <span
-                      class="bp3-icon bp3-icon-chevron-down StyledProps--main StyledProps--padding-small"
-                      icon="chevron-down"
+                      class="bp3-popover-target Text--targetClass"
+                    >
+                      <p
+                        class="StyledProps--font StyledProps--main label StyledProps--color StyledProps--color-grey800"
+                        tabindex="0"
+                      >
+                        swaraj gcp
+                      </p>
+                    </span>
+                  </span>
+                  <div
+                    class="rightStatus"
+                  >
+                    <span
+                      class="bp3-icon bp3-icon-full-circle StyledProps--main status greenStatus"
+                      data-testid="crf-status"
+                      icon="full-circle"
                     >
                       <svg
-                        data-icon="chevron-down"
-                        height="14"
+                        data-icon="full-circle"
+                        height="6"
                         viewBox="0 0 16 16"
-                        width="14"
+                        width="6"
                       >
                         <desc>
-                          chevron-down
+                          full-circle
                         </desc>
                         <path
-                          d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                          d="M8 0a8 8 0 100 16A8 8 0 108 0z"
                           fill-rule="evenodd"
                         />
                       </svg>
                     </span>
-                  </span>
+                    <span
+                      class="Tag--main"
+                    >
+                      <span
+                        class="bp3-tag bp3-minimal"
+                        id="tag"
+                      >
+                        <span
+                          class="bp3-text-overflow-ellipsis bp3-fill"
+                        >
+                          project
+                        </span>
+                      </span>
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </div>
+              </span>
+              <span
+                class="bp3-icon bp3-icon-chevron-down StyledProps--main"
+                icon="chevron-down"
+              >
+                <svg
+                  data-icon="chevron-down"
+                  height="14"
+                  viewBox="0 0 16 16"
+                  width="14"
+                >
+                  <desc>
+                    chevron-down
+                  </desc>
+                  <path
+                    d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+            </button>
           </div>
         </div>
         <span
@@ -127,7 +168,7 @@ exports[`CreateUpdateSecret GCP Secret manager Text Secret in GCP 1`] = `
               </div>
               <div
                 class="bp3-form-group bp3-disabled"
-                data-id="name-1"
+                data-id="name-0"
               >
                 <label
                   class="bp3-label"
@@ -207,7 +248,6 @@ exports[`CreateUpdateSecret GCP Secret manager Text Secret in GCP 1`] = `
         </span>
         <div
           class="bp3-form-group"
-          data-id="value-2"
         >
           <label
             class="bp3-label"
@@ -253,7 +293,6 @@ exports[`CreateUpdateSecret GCP Secret manager Text Secret in GCP 1`] = `
             >
               <div
                 class="bp3-form-group bp3-disabled"
-                data-id="configureRegions-3"
               >
                 <div
                   class="bp3-form-content"
@@ -262,7 +301,6 @@ exports[`CreateUpdateSecret GCP Secret manager Text Secret in GCP 1`] = `
                     class="bp3-control bp3-checkbox bp3-disabled StyledProps--font Checkbox--checkbox Checkbox--checked StyledProps--main StyledProps--inline"
                   >
                     <input
-                      checked=""
                       disabled=""
                       name="configureRegions"
                       type="checkbox"
@@ -281,7 +319,6 @@ exports[`CreateUpdateSecret GCP Secret manager Text Secret in GCP 1`] = `
               </div>
               <div
                 class="bp3-form-group bp3-disabled"
-                data-id="regions-4"
               >
                 <label
                   class="bp3-label"
@@ -355,7 +392,6 @@ exports[`CreateUpdateSecret GCP Secret manager Text Secret in GCP 1`] = `
         </span>
         <div
           class="bp3-form-group"
-          data-id="description-5"
         >
           <label
             class="bp3-label"
@@ -385,7 +421,6 @@ exports[`CreateUpdateSecret GCP Secret manager Text Secret in GCP 1`] = `
         </div>
         <div
           class="bp3-form-group"
-          data-id="tags-6"
         >
           <label
             class="bp3-label"

--- a/src/modules/27-platform/secrets/components/MutiTypeSecretInput/__test__/__snapshots__/MutiTypeSecretInput.test.tsx.snap
+++ b/src/modules/27-platform/secrets/components/MutiTypeSecretInput/__test__/__snapshots__/MutiTypeSecretInput.test.tsx.snap
@@ -445,7 +445,7 @@ exports[`SecretInput render 2`] = `
                                     class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--font-size-small StyledProps--font-weight-light StyledProps--color StyledProps--color-grey600"
                                     style="--text-line-clamp: 1;"
                                   >
-                                    common.ID: a1.harnessSecretManager
+                                    common.ID: a1
                                   </p>
                                 </div>
                               </div>
@@ -589,7 +589,7 @@ exports[`SecretInput render 2`] = `
                                     class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--font-size-small StyledProps--font-weight-light StyledProps--color StyledProps--color-grey600"
                                     style="--text-line-clamp: 1;"
                                   >
-                                    common.ID: demo1.harnessSecretManager
+                                    common.ID: demo1
                                   </p>
                                 </div>
                               </div>
@@ -733,7 +733,7 @@ exports[`SecretInput render 2`] = `
                                     class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--font-size-small StyledProps--font-weight-light StyledProps--color StyledProps--color-grey600"
                                     style="--text-line-clamp: 1;"
                                   >
-                                    common.ID: text1.vault1
+                                    common.ID: text1
                                   </p>
                                 </div>
                               </div>

--- a/src/modules/27-platform/secrets/components/MutiTypeSecretInput/__test__/secretsListMockData.json
+++ b/src/modules/27-platform/secrets/components/MutiTypeSecretInput/__test__/secretsListMockData.json
@@ -14,7 +14,7 @@
           "tags": {},
           "description": "",
           "spec": {
-            "secretManagerIdentifier": "harnessSecretManager",
+            "secretManagerIdentifier": "account.harnessSecretManager",
             "valueType": "Inline",
             "value": null
           }

--- a/src/modules/27-platform/secrets/components/SecretInput/__test__/__snapshots__/SecretInput.test.tsx.snap
+++ b/src/modules/27-platform/secrets/components/SecretInput/__test__/__snapshots__/SecretInput.test.tsx.snap
@@ -487,7 +487,7 @@ exports[`SecretInput render and pick a secret 2`] = `
                                     class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--font-size-small StyledProps--font-weight-light StyledProps--color StyledProps--color-grey600"
                                     style="--text-line-clamp: 1;"
                                   >
-                                    common.ID: a1.harnessSecretManager
+                                    common.ID: a1
                                   </p>
                                 </div>
                               </div>
@@ -631,7 +631,7 @@ exports[`SecretInput render and pick a secret 2`] = `
                                     class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--font-size-small StyledProps--font-weight-light StyledProps--color StyledProps--color-grey600"
                                     style="--text-line-clamp: 1;"
                                   >
-                                    common.ID: demo1.harnessSecretManager
+                                    common.ID: demo1
                                   </p>
                                 </div>
                               </div>
@@ -775,7 +775,7 @@ exports[`SecretInput render and pick a secret 2`] = `
                                     class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--font-size-small StyledProps--font-weight-light StyledProps--color StyledProps--color-grey600"
                                     style="--text-line-clamp: 1;"
                                   >
-                                    common.ID: text1.vault1
+                                    common.ID: text1
                                   </p>
                                 </div>
                               </div>

--- a/src/modules/27-platform/secrets/components/SecretInput/__test__/secretMockData.json
+++ b/src/modules/27-platform/secrets/components/SecretInput/__test__/secretMockData.json
@@ -8,7 +8,7 @@
       "tags": {},
       "description": "",
       "spec": {
-        "secretManagerIdentifier": "harnessSecretManager",
+        "secretManagerIdentifier": "account.harnessSecretManager",
         "valueType": "Inline",
         "value": null
       }

--- a/src/modules/27-platform/secrets/components/SecretReference/SecretReference.tsx
+++ b/src/modules/27-platform/secrets/components/SecretReference/SecretReference.tsx
@@ -16,7 +16,6 @@ import {
   Failure,
   listSecretsV2Promise,
   SecretDTOV2,
-  SecretTextSpecDTO,
   ResponsePageSecretResponseWrapper,
   ConnectorInfoDTO
 } from 'services/cd-ng'
@@ -317,19 +316,9 @@ const SecretReference: React.FC<SecretReferenceProps> = props => {
                       <Text lineClamp={1} font={{ weight: 'bold' }} color={Color.BLACK}>
                         {item.record.name}
                       </Text>
-                      {item.record.type === SecretTypeEnum.SECRET_TEXT ||
-                      item.record.type === SecretTypeEnum.SECRET_FILE ? (
-                        <Text lineClamp={1} font={{ size: 'small', weight: 'light' }} color={Color.GREY_600}>
-                          {`${getString('common.ID')}: ${item.identifier}.${
-                            (item.record.spec as SecretTextSpecDTO).secretManagerIdentifier
-                          }`}
-                        </Text>
-                      ) : null}
-                      {item.record.type === SecretTypeEnum.SSH_KEY ? (
-                        <Text lineClamp={1} font={{ size: 'small', weight: 'light' }} color={Color.GREY_600}>
-                          {`${getString('common.ID')}: ${item.identifier}`}
-                        </Text>
-                      ) : null}
+                      <Text lineClamp={1} font={{ size: 'small', weight: 'light' }} color={Color.GREY_600}>
+                        {`${getString('common.ID')}: ${item.identifier}`}
+                      </Text>
                     </Layout.Vertical>
                   </Layout.Horizontal>
                 </Layout.Horizontal>

--- a/src/modules/27-platform/secrets/components/SecretReference/__test__/__snapshots__/SecretReference.test.tsx.snap
+++ b/src/modules/27-platform/secrets/components/SecretReference/__test__/__snapshots__/SecretReference.test.tsx.snap
@@ -461,7 +461,7 @@ exports[`Secret Reference render with no secret type 1`] = `
                                   class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--font-size-small StyledProps--font-weight-light StyledProps--color StyledProps--color-grey600"
                                   style="--text-line-clamp: 1;"
                                 >
-                                  common.ID: text1.vault1
+                                  common.ID: text1
                                 </p>
                               </div>
                             </div>
@@ -751,7 +751,7 @@ exports[`Secret Reference render with secret type file 1`] = `
                                   class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--font-size-small StyledProps--font-weight-light StyledProps--color StyledProps--color-grey600"
                                   style="--text-line-clamp: 1;"
                                 >
-                                  common.ID: text1.vault1
+                                  common.ID: text1
                                 </p>
                               </div>
                             </div>
@@ -1041,7 +1041,7 @@ exports[`Secret Reference render with secret type text 1`] = `
                                   class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--font-size-small StyledProps--font-weight-light StyledProps--color StyledProps--color-grey600"
                                   style="--text-line-clamp: 1;"
                                 >
-                                  common.ID: text1.vault1
+                                  common.ID: text1
                                 </p>
                               </div>
                             </div>

--- a/src/modules/27-platform/secrets/pages/secrets/__tests__/__snapshots__/SecretsPage.test.tsx.snap
+++ b/src/modules/27-platform/secrets/pages/secrets/__tests__/__snapshots__/SecretsPage.test.tsx.snap
@@ -674,7 +674,13 @@ exports[`Secrets List Delete SSH 1`] = `
                 class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-black"
                 style="--text-line-clamp: 1; width: 230px;"
               >
-                harnessSecretManager
+                platform.connectors.title.secretManager: harnessSecretManager
+              </p>
+              <p
+                class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
+                style="--text-line-clamp: 1; width: 230px;"
+              >
+                projectLabel: undefined
               </p>
               <p
                 class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
@@ -873,7 +879,13 @@ exports[`Secrets List Delete SSH 1`] = `
                 class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-black"
                 style="--text-line-clamp: 1; width: 230px;"
               >
-                vault1
+                platform.connectors.title.secretManager: vault1
+              </p>
+              <p
+                class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
+                style="--text-line-clamp: 1; width: 230px;"
+              >
+                projectLabel: undefined
               </p>
               <p
                 class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
@@ -1044,7 +1056,13 @@ exports[`Secrets List Delete SSH 1`] = `
                 class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-black"
                 style="--text-line-clamp: 1; width: 230px;"
               >
-                harnessSecretManager
+                platform.connectors.title.secretManager: harnessSecretManager
+              </p>
+              <p
+                class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
+                style="--text-line-clamp: 1; width: 230px;"
+              >
+                projectLabel: undefined
               </p>
               <p
                 class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
@@ -1990,7 +2008,13 @@ exports[`Secrets List render 1`] = `
                 class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-black"
                 style="--text-line-clamp: 1; width: 230px;"
               >
-                harnessSecretManager
+                platform.connectors.title.secretManager: harnessSecretManager
+              </p>
+              <p
+                class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
+                style="--text-line-clamp: 1; width: 230px;"
+              >
+                projectLabel: undefined
               </p>
               <p
                 class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
@@ -2189,7 +2213,13 @@ exports[`Secrets List render 1`] = `
                 class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-black"
                 style="--text-line-clamp: 1; width: 230px;"
               >
-                vault1
+                platform.connectors.title.secretManager: vault1
+              </p>
+              <p
+                class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
+                style="--text-line-clamp: 1; width: 230px;"
+              >
+                projectLabel: undefined
               </p>
               <p
                 class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
@@ -2360,7 +2390,13 @@ exports[`Secrets List render 1`] = `
                 class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-black"
                 style="--text-line-clamp: 1; width: 230px;"
               >
-                harnessSecretManager
+                platform.connectors.title.secretManager: harnessSecretManager
+              </p>
+              <p
+                class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
+                style="--text-line-clamp: 1; width: 230px;"
+              >
+                projectLabel: undefined
               </p>
               <p
                 class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
@@ -3483,7 +3519,13 @@ exports[`Secrets Page render data 1`] = `
                 class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-black"
                 style="--text-line-clamp: 1; width: 230px;"
               >
-                harnessSecretManager
+                platform.connectors.title.secretManager: harnessSecretManager
+              </p>
+              <p
+                class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
+                style="--text-line-clamp: 1; width: 230px;"
+              >
+                projectLabel: undefined
               </p>
               <p
                 class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
@@ -3682,7 +3724,13 @@ exports[`Secrets Page render data 1`] = `
                 class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-black"
                 style="--text-line-clamp: 1; width: 230px;"
               >
-                vault1
+                platform.connectors.title.secretManager: vault1
+              </p>
+              <p
+                class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
+                style="--text-line-clamp: 1; width: 230px;"
+              >
+                projectLabel: undefined
               </p>
               <p
                 class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
@@ -3853,7 +3901,13 @@ exports[`Secrets Page render data 1`] = `
                 class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-black"
                 style="--text-line-clamp: 1; width: 230px;"
               >
-                harnessSecretManager
+                platform.connectors.title.secretManager: harnessSecretManager
+              </p>
+              <p
+                class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
+                style="--text-line-clamp: 1; width: 230px;"
+              >
+                projectLabel: undefined
               </p>
               <p
                 class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"

--- a/src/modules/27-platform/secrets/pages/secrets/__tests__/__snapshots__/SecretsPage.test.tsx.snap
+++ b/src/modules/27-platform/secrets/pages/secrets/__tests__/__snapshots__/SecretsPage.test.tsx.snap
@@ -680,7 +680,7 @@ exports[`Secrets List Delete SSH 1`] = `
                 class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
                 style="--text-line-clamp: 1; width: 230px;"
               >
-                projectLabel: undefined
+                account: undefined
               </p>
               <p
                 class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
@@ -885,7 +885,7 @@ exports[`Secrets List Delete SSH 1`] = `
                 class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
                 style="--text-line-clamp: 1; width: 230px;"
               >
-                projectLabel: undefined
+                account: undefined
               </p>
               <p
                 class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
@@ -1062,7 +1062,7 @@ exports[`Secrets List Delete SSH 1`] = `
                 class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
                 style="--text-line-clamp: 1; width: 230px;"
               >
-                projectLabel: undefined
+                account: undefined
               </p>
               <p
                 class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
@@ -2014,7 +2014,7 @@ exports[`Secrets List render 1`] = `
                 class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
                 style="--text-line-clamp: 1; width: 230px;"
               >
-                projectLabel: undefined
+                account: undefined
               </p>
               <p
                 class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
@@ -2219,7 +2219,7 @@ exports[`Secrets List render 1`] = `
                 class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
                 style="--text-line-clamp: 1; width: 230px;"
               >
-                projectLabel: undefined
+                account: undefined
               </p>
               <p
                 class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
@@ -2396,7 +2396,7 @@ exports[`Secrets List render 1`] = `
                 class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
                 style="--text-line-clamp: 1; width: 230px;"
               >
-                projectLabel: undefined
+                account: undefined
               </p>
               <p
                 class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
@@ -3525,7 +3525,7 @@ exports[`Secrets Page render data 1`] = `
                 class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
                 style="--text-line-clamp: 1; width: 230px;"
               >
-                projectLabel: undefined
+                account: undefined
               </p>
               <p
                 class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
@@ -3730,7 +3730,7 @@ exports[`Secrets Page render data 1`] = `
                 class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
                 style="--text-line-clamp: 1; width: 230px;"
               >
-                projectLabel: undefined
+                account: undefined
               </p>
               <p
                 class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
@@ -3907,7 +3907,7 @@ exports[`Secrets Page render data 1`] = `
                 class="StyledProps--font Text--lineclamp StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"
                 style="--text-line-clamp: 1; width: 230px;"
               >
-                projectLabel: undefined
+                account: undefined
               </p>
               <p
                 class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-grey600 StyledProps--font-size-small"


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->
JIRA: https://harness.atlassian.net/browse/PL-38949
Secrets can now be created in child scope using SecretManager (SM) of the parent scope.
A `Project` scope secret can use SM of `Org` or `Account` scope.
An `Org` scope secret can use SM of `Account` scope.

**Changes:** To enable this, in CreateUpdateSecret Modal, the Select input has been replaced with a ConnectorReferenceField that lets the user select Connector References of Secret Managers.


#### Screenshots & Videos

BEFORE: (Select Dropdown to select Secret Manager)

https://github.com/harness/harness-core-ui/assets/96057095/51e9f9fa-b583-4111-b9b6-2a166d245930



AFTER: (ConnectorReference field to select Secret Manager)

https://github.com/harness/harness-core-ui/assets/96057095/d829e11a-b12f-4083-a0e0-30d6ef3ff7e7



--
BEFORE: (secret ID and SecretManagerID shown in SecretReference)
<img width="975" alt="image" src="https://github.com/harness/harness-core-ui/assets/96057095/0d90585c-2484-401f-9a09-489ddcca0453">


AFTER: (only secret ID shown in SecretReference)
<img width="1025" alt="image" src="https://github.com/harness/harness-core-ui/assets/96057095/314b83c5-7f49-45c7-9ab6-e2022704cf36">


NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
