### PR TITLE
fix: [OIP-755]: Add tooltip data ids to risk category items

### DIFF
--- a/src/modules/85-cv/pages/health-source/common/SelectHealthSourceServices/components/RiskProfile/RiskProfile.utils.ts
+++ b/src/modules/85-cv/pages/health-source/common/SelectHealthSourceServices/components/RiskProfile/RiskProfile.utils.ts
@@ -6,6 +6,7 @@
  */
 
 import type { IOptionProps } from '@blueprintjs/core'
+import { RadioGroupProps } from '@harness/uicore/dist/components/FormikForm/FormikForm'
 import type { MetricPackDTO, RiskCategoryDTO } from 'services/cv'
 
 export function getRiskCategoryOptions(metricPacks?: MetricPackDTO[]): IOptionProps[] {
@@ -32,17 +33,19 @@ export function getRiskCategoryOptions(metricPacks?: MetricPackDTO[]): IOptionPr
   return riskCategoryOptions
 }
 
-export function getRiskCategoryOptionsV2(riskCategories?: RiskCategoryDTO[]): IOptionProps[] {
+export function getRiskCategoryOptionsV2(riskCategories?: RiskCategoryDTO[]): RadioGroupProps['items'] {
   if (!Array.isArray(riskCategories) || !riskCategories?.length) {
     return []
   }
 
-  const riskCategoryOptions: IOptionProps[] = []
+  const riskCategoryOptions: RadioGroupProps['items'] = []
   for (const riskCategory of riskCategories) {
-    if (riskCategory?.identifier && riskCategory?.displayName) {
+    const { identifier, displayName } = riskCategory || {}
+    if (identifier && displayName) {
       riskCategoryOptions.push({
-        label: riskCategory.displayName,
-        value: riskCategory.identifier
+        label: displayName,
+        value: identifier,
+        tooltipId: `RiskCategory_${identifier}`
       })
     }
   }

--- a/src/modules/85-cv/pages/health-source/connectors/AppDynamics/__tests__/__snapshots__/AppDMonitoredSourceTemplate.test.tsx.snap
+++ b/src/modules/85-cv/pages/health-source/connectors/AppDynamics/__tests__/__snapshots__/AppDMonitoredSourceTemplate.test.tsx.snap
@@ -1034,7 +1034,12 @@ exports[`Unit tests for createAppd monitoring source Component renders in edit m
                                                 <span
                                                   class="RadioButton--radioIcon"
                                                 />
-                                                Errors
+                                                <span
+                                                  class="RadioButton--tooltipAlign"
+                                                  data-tooltip-id="RiskCategory_Errors"
+                                                >
+                                                  Errors
+                                                </span>
                                               </label>
                                               <label
                                                 class="RadioButton--radio StyledProps--main"
@@ -1048,7 +1053,12 @@ exports[`Unit tests for createAppd monitoring source Component renders in edit m
                                                 <span
                                                   class="RadioButton--radioIcon"
                                                 />
-                                                Infrastructure
+                                                <span
+                                                  class="RadioButton--tooltipAlign"
+                                                  data-tooltip-id="RiskCategory_Infrastructure"
+                                                >
+                                                  Infrastructure
+                                                </span>
                                               </label>
                                               <label
                                                 class="RadioButton--radio StyledProps--main"
@@ -1062,7 +1072,12 @@ exports[`Unit tests for createAppd monitoring source Component renders in edit m
                                                 <span
                                                   class="RadioButton--radioIcon"
                                                 />
-                                                Performance/Throughput
+                                                <span
+                                                  class="RadioButton--tooltipAlign"
+                                                  data-tooltip-id="RiskCategory_Performance_Throughput"
+                                                >
+                                                  Performance/Throughput
+                                                </span>
                                               </label>
                                               <label
                                                 class="RadioButton--radio StyledProps--main"
@@ -1076,7 +1091,12 @@ exports[`Unit tests for createAppd monitoring source Component renders in edit m
                                                 <span
                                                   class="RadioButton--radioIcon"
                                                 />
-                                                Performance/Other
+                                                <span
+                                                  class="RadioButton--tooltipAlign"
+                                                  data-tooltip-id="RiskCategory_Performance_Other"
+                                                >
+                                                  Performance/Other
+                                                </span>
                                               </label>
                                               <label
                                                 class="RadioButton--radio StyledProps--main"
@@ -1090,7 +1110,12 @@ exports[`Unit tests for createAppd monitoring source Component renders in edit m
                                                 <span
                                                   class="RadioButton--radioIcon"
                                                 />
-                                                Performance/Response Time
+                                                <span
+                                                  class="RadioButton--tooltipAlign"
+                                                  data-tooltip-id="RiskCategory_Performance_ResponseTime"
+                                                >
+                                                  Performance/Response Time
+                                                </span>
                                               </label>
                                             </div>
                                           </div>

--- a/src/modules/85-cv/pages/health-source/connectors/CommonHealthSource/components/CustomMetricForm/components/Assign/__tests__/__snapshots__/AssignQuery.test.tsx.snap
+++ b/src/modules/85-cv/pages/health-source/connectors/CommonHealthSource/components/CustomMetricForm/components/Assign/__tests__/__snapshots__/AssignQuery.test.tsx.snap
@@ -804,7 +804,12 @@ exports[`Validate AssignQuery should render form errors 1`] = `
                       <span
                         class="RadioButton--radioIcon"
                       />
-                      Errors
+                      <span
+                        class="RadioButton--tooltipAlign"
+                        data-tooltip-id="RiskCategory_Errors"
+                      >
+                        Errors
+                      </span>
                     </label>
                     <label
                       class="RadioButton--radio StyledProps--main"
@@ -818,7 +823,12 @@ exports[`Validate AssignQuery should render form errors 1`] = `
                       <span
                         class="RadioButton--radioIcon"
                       />
-                      Infrastructure
+                      <span
+                        class="RadioButton--tooltipAlign"
+                        data-tooltip-id="RiskCategory_Infrastructure"
+                      >
+                        Infrastructure
+                      </span>
                     </label>
                     <label
                       class="RadioButton--radio StyledProps--main"
@@ -832,7 +842,12 @@ exports[`Validate AssignQuery should render form errors 1`] = `
                       <span
                         class="RadioButton--radioIcon"
                       />
-                      Performance/Throughput
+                      <span
+                        class="RadioButton--tooltipAlign"
+                        data-tooltip-id="RiskCategory_Performance_Throughput"
+                      >
+                        Performance/Throughput
+                      </span>
                     </label>
                     <label
                       class="RadioButton--radio StyledProps--main"
@@ -846,7 +861,12 @@ exports[`Validate AssignQuery should render form errors 1`] = `
                       <span
                         class="RadioButton--radioIcon"
                       />
-                      Performance/Other
+                      <span
+                        class="RadioButton--tooltipAlign"
+                        data-tooltip-id="RiskCategory_Performance_Other"
+                      >
+                        Performance/Other
+                      </span>
                     </label>
                     <label
                       class="RadioButton--radio StyledProps--main"
@@ -860,7 +880,12 @@ exports[`Validate AssignQuery should render form errors 1`] = `
                       <span
                         class="RadioButton--radioIcon"
                       />
-                      Performance/Response Time
+                      <span
+                        class="RadioButton--tooltipAlign"
+                        data-tooltip-id="RiskCategory_Performance_ResponseTime"
+                      >
+                        Performance/Response Time
+                      </span>
                     </label>
                   </div>
                 </div>

--- a/src/modules/85-cv/pages/health-source/connectors/CommonHealthSource/components/CustomMetricForm/components/Assign/components/RiskProfile/RiskProfile.utils.ts
+++ b/src/modules/85-cv/pages/health-source/connectors/CommonHealthSource/components/CustomMetricForm/components/Assign/components/RiskProfile/RiskProfile.utils.ts
@@ -5,20 +5,22 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import type { IOptionProps } from '@blueprintjs/core'
+import { RadioGroupProps } from '@harness/uicore/dist/components/FormikForm/FormikForm'
 import type { RiskCategoryDTO } from 'services/cv'
 
-export function getRiskCategoryOptionsV2(riskCategories?: RiskCategoryDTO[]): IOptionProps[] {
+export function getRiskCategoryOptionsV2(riskCategories?: RiskCategoryDTO[]): RadioGroupProps['items'] {
   if (!Array.isArray(riskCategories) || !riskCategories?.length) {
     return []
   }
 
-  const riskCategoryOptions: IOptionProps[] = []
+  const riskCategoryOptions: RadioGroupProps['items'] = []
   for (const riskCategory of riskCategories) {
-    if (riskCategory?.identifier && riskCategory?.displayName) {
+    const { identifier, displayName } = riskCategory || {}
+    if (identifier && displayName) {
       riskCategoryOptions.push({
-        label: riskCategory.displayName,
-        value: riskCategory.identifier
+        label: displayName,
+        value: identifier,
+        tooltipId: `RiskCategory_${identifier}`
       })
     }
   }

--- a/src/modules/85-cv/pages/health-source/connectors/CommonHealthSource/components/CustomMetricForm/components/Assign/components/RiskProfile/tests/RiskProfile.test.tsx
+++ b/src/modules/85-cv/pages/health-source/connectors/CommonHealthSource/components/CustomMetricForm/components/Assign/components/RiskProfile/tests/RiskProfile.test.tsx
@@ -187,8 +187,8 @@ describe('Unit tests for RiskProfile', () => {
     expect(getRiskCategoryOptionsV2([{}] as any)).toEqual([])
     expect(getRiskCategoryOptionsV2([{ displayName: 'Id 101' }] as any)).toEqual([])
     expect(getRiskCategoryOptionsV2([{ identifier: 'id101' }] as any)).toEqual([])
-    expect(getRiskCategoryOptionsV2([{ identifier: 'id101', displayName: 'Id 101' }] as any)).toEqual([
-      { label: 'Id 101', value: 'id101' }
-    ])
+    expect(
+      getRiskCategoryOptionsV2([{ identifier: 'id101', displayName: 'Id 101', tooltipId: 'RiskCategory_id101' }] as any)
+    ).toEqual([{ label: 'Id 101', value: 'id101' }])
   })
 })

--- a/src/modules/85-cv/pages/health-source/connectors/CommonHealthSource/components/CustomMetricForm/components/Assign/components/RiskProfile/tests/RiskProfile.test.tsx
+++ b/src/modules/85-cv/pages/health-source/connectors/CommonHealthSource/components/CustomMetricForm/components/Assign/components/RiskProfile/tests/RiskProfile.test.tsx
@@ -187,8 +187,8 @@ describe('Unit tests for RiskProfile', () => {
     expect(getRiskCategoryOptionsV2([{}] as any)).toEqual([])
     expect(getRiskCategoryOptionsV2([{ displayName: 'Id 101' }] as any)).toEqual([])
     expect(getRiskCategoryOptionsV2([{ identifier: 'id101' }] as any)).toEqual([])
-    expect(
-      getRiskCategoryOptionsV2([{ identifier: 'id101', displayName: 'Id 101', tooltipId: 'RiskCategory_id101' }] as any)
-    ).toEqual([{ label: 'Id 101', value: 'id101' }])
+    expect(getRiskCategoryOptionsV2([{ identifier: 'id101', displayName: 'Id 101' }] as any)).toEqual([
+      { label: 'Id 101', value: 'id101', tooltipId: 'RiskCategory_id101' }
+    ])
   })
 })


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->

#### Screenshots

Mocked tooltip UI:

<img width="1023" alt="Pasted Graphic 21" src="https://github.com/harness/harness-core-ui/assets/95267551/d21ac366-0c9c-48be-b687-59368cc574cb">
<img width="542" alt="Risk Category" src="https://github.com/harness/harness-core-ui/assets/95267551/72918f7b-995e-4441-afe0-4b783162ca9b">


<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
