### PR TITLE
fix: [CI-8885]: delete codebase properties only if no CI stage/template with codebase enabled

### DIFF
--- a/src/modules/75-ci/components/PipelineStudio/BuildStageSetupShell/BuildStageSetupShell.tsx
+++ b/src/modules/75-ci/components/PipelineStudio/BuildStageSetupShell/BuildStageSetupShell.tsx
@@ -132,15 +132,15 @@ const BuildStageSetupShell: React.FC<BuildStageSetupShellProps> = ({ moduleIcon 
     queryParams: {
       accountIdentifier: accountId,
       orgIdentifier,
-      pipelineIdentifier: originalPipeline.identifier,
+      pipelineIdentifier: pipeline.identifier,
       projectIdentifier,
       ...getGitQueryParamsWithParentScope({ storeMetadata, params, repoIdentifier, branch })
     },
     requestOptions: { headers: { 'Load-From-Cache': 'true' } },
     body: {
-      originalEntityYaml: yamlStringify({ pipeline: originalPipeline })
+      originalEntityYaml: yamlStringify({ pipeline: pipeline })
     },
-    lazy: isEmpty(originalPipeline)
+    lazy: isEmpty(pipeline)
   })
 
   React.useEffect(() => {


### PR DESCRIPTION
### Summary

delete codebase properties only if no CI stage/template with codebase enabled

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
