### PR TITLE
fix: [CDS-76660]: escape newline characters for multi text input fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@harness/ng-tooltip": "^1.31.153",
     "@harness/telemetry": "^1.0.42",
     "@harness/ts-transform-paths": "1.0.1",
-    "@harness/uicore": "^3.148.5",
+    "@harness/uicore": "^3.148.6",
     "@harness/use-modal": "1.1.0",
     "@harnessio/ff-react-client-sdk": "1.3.0",
     "@harnessio/react-audit-service-client": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@harness/ng-tooltip": "^1.31.153",
     "@harness/telemetry": "^1.0.42",
     "@harness/ts-transform-paths": "1.0.1",
-    "@harness/uicore": "^3.148.6",
+    "@harness/uicore": "^3.148.7",
     "@harness/use-modal": "1.1.0",
     "@harnessio/ff-react-client-sdk": "1.3.0",
     "@harnessio/react-audit-service-client": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2012,10 +2012,10 @@
   resolved "https://npm.pkg.github.com/download/@harness/ts-transform-paths/1.0.1/8b6ee76cefebc3d6c04f3609d4df94b5ecb15d71#8b6ee76cefebc3d6c04f3609d4df94b5ecb15d71"
   integrity sha512-ktBF6O8vRCBGjH/D7i5SUOufbUzGq+SFusNqizb1NV3g2777LhWhXu/Qb2voRBZMbL7CxxYTpyG70hh5RBwi0w==
 
-"@harness/uicore@^3.148.6":
-  version "3.148.6"
-  resolved "https://npm.pkg.github.com/download/@harness/uicore/3.148.6/f3b5b9196689e910bb14adb680e0b8da2bb1a25b#f3b5b9196689e910bb14adb680e0b8da2bb1a25b"
-  integrity sha512-Lg/ztWmk+3h+CtjJQHAxfMeDGF075Aa4DQ+NJTHtalEuaMudwk5AsNJ6E51wCJ3pgOWGjwDQHtiWaCtOHaS58A==
+"@harness/uicore@^3.148.7":
+  version "3.148.7"
+  resolved "https://npm.pkg.github.com/download/@harness/uicore/3.148.7/025e0a7d33143fd86c29a67275ec48c56fe2bb02#025e0a7d33143fd86c29a67275ec48c56fe2bb02"
+  integrity sha512-Am+2K3UDit0PN3lDgASJHi+YD/q9mXzakUsPo0Nc3x9XGvK8+Ag7Pj/6vmrseQUlpCuiyzh+iNFaeQm4s3G0IQ==
 
 "@harness/use-modal@1.1.0":
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2012,10 +2012,10 @@
   resolved "https://npm.pkg.github.com/download/@harness/ts-transform-paths/1.0.1/8b6ee76cefebc3d6c04f3609d4df94b5ecb15d71#8b6ee76cefebc3d6c04f3609d4df94b5ecb15d71"
   integrity sha512-ktBF6O8vRCBGjH/D7i5SUOufbUzGq+SFusNqizb1NV3g2777LhWhXu/Qb2voRBZMbL7CxxYTpyG70hh5RBwi0w==
 
-"@harness/uicore@^3.148.5":
-  version "3.148.5"
-  resolved "https://npm.pkg.github.com/download/@harness/uicore/3.148.5/8ad57c15d56c08a98ea87cf35048ff61a48d05cf#8ad57c15d56c08a98ea87cf35048ff61a48d05cf"
-  integrity sha512-yd1piTLCsm9Egz/UDqgWed8nFHopSxYR0qjd7F5YlPZsGWKLh9AFI5JwA9Qm+fwsjo9ZKnvDkHY9/WXWvzDyIg==
+"@harness/uicore@^3.148.6":
+  version "3.148.6"
+  resolved "https://npm.pkg.github.com/download/@harness/uicore/3.148.6/f3b5b9196689e910bb14adb680e0b8da2bb1a25b#f3b5b9196689e910bb14adb680e0b8da2bb1a25b"
+  integrity sha512-Lg/ztWmk+3h+CtjJQHAxfMeDGF075Aa4DQ+NJTHtalEuaMudwk5AsNJ6E51wCJ3pgOWGjwDQHtiWaCtOHaS58A==
 
 "@harness/use-modal@1.1.0":
   version "1.1.0"


### PR DESCRIPTION
### Summary

Problem :- When  `"a\nb"` is entered in the YAML view the Monaco Editor Indents the new line properly but in visual view the data is being rendered as `ab`. 

Solution :- Whenever the `MultiTextInput` receives `'a\nb'` it should render it as it as thus  escaped the new line chars.

#### Screenshots

https://github.com/harness/uicore/assets/106532291/8ada3e3b-99d4-4b6b-b749-c56f45740166

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
