### PR TITLE
fix: [CDS-76971]: styling being overridden for stage/step node

### DIFF
--- a/src/modules/70-pipeline/components/PipelineDiagram/Nodes/utils.tsx
+++ b/src/modules/70-pipeline/components/PipelineDiagram/Nodes/utils.tsx
@@ -96,5 +96,5 @@ export const getBaseDotNotationWithoutEntityIdentifier = (dotNotation = ''): str
 }
 
 export const getConditionalClassName = (isDisabled: boolean, className?: string): { className?: string } => {
-  return isDisabled ? { className: defaultCss.disabledIcon } : { className }
+  return isDisabled ? { className: defaultCss.disabledIcon } : className ? { className } : {}
 }


### PR DESCRIPTION
### Summary

- Since conditional spread was happening at last in the PipelineStage/Step node, the default className added on selection was overridden by `className: undefined`.

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
