### PR TITLE
feat: [CDB-1067]: enable dashboards for CCM team license

### DIFF
--- a/src/modules/10-common/RouteDefinitions.ts
+++ b/src/modules/10-common/RouteDefinitions.ts
@@ -2166,7 +2166,6 @@ const routes = {
       `/${module}/orgs/${orgIdentifier}/projects/${projectIdentifier}/setup/tickets`
   ),
   /********************************************************************************************************************/
-  toOldCustomDashboard: withAccountId(() => '/home/dashboards*'),
   toCustomDashboard: withAccountId(() => '/dashboards'),
   toCustomDashboardHome: withAccountId(
     ({ folderId }: { folderId?: string }) => `/dashboards/folder/${folderId ? folderId : 'shared'}`

--- a/src/modules/45-dashboards/RouteDestinations.tsx
+++ b/src/modules/45-dashboards/RouteDestinations.tsx
@@ -56,9 +56,6 @@ const CdbMicroFrontendPath = React.lazy(() => import('cdbui/MicroFrontendApp'))
 
 export const CdbNonMfeRoutes = (
   <>
-    <Route path={routes.toOldCustomDashboard({ ...accountPathProps })}>
-      <RedirectToHome />
-    </Route>
     <Route path={routes.toCustomDashboard({ ...accountPathProps })} exact>
       <RedirectToHome />
     </Route>
@@ -93,7 +90,6 @@ export const CdbMfeRoutes = (
     <RouteWithLayout
       layout={MinimalLayout}
       path={[
-        routes.toOldCustomDashboard({ ...accountPathProps }),
         routes.toCustomDashboard({ ...accountPathProps }),
         routes.toCustomDashboardHome({ ...accountPathProps, folderId: ':folderId' }),
         routes.toCustomFolderHome({ ...accountPathProps }),

--- a/src/modules/45-dashboards/pages/DashboardsPage.tsx
+++ b/src/modules/45-dashboards/pages/DashboardsPage.tsx
@@ -11,6 +11,7 @@ import { Editions } from '@common/constants/SubscriptionTypes'
 import LevelUpBanner from '@common/components/FeatureWarning/LevelUpBanner'
 import type { ModuleLicenseDTO } from 'services/cd-ng'
 import { useLicenseStore } from 'framework/LicenseStore/LicenseStoreContext'
+import { ModuleName } from 'framework/types/ModuleName'
 import { isOnPrem } from '@common/utils/utils'
 import { useStrings } from 'framework/strings'
 
@@ -26,10 +27,20 @@ const isEnterpriseLicense = (
   )
 }
 
+const isCcmTeamLicense = (
+  licenseInformation: Record<string, ModuleLicenseDTO> | Record<string, undefined>
+): boolean => {
+  const ccmLicense = licenseInformation[ModuleName.CE]
+  return (
+    ccmLicense?.status === 'ACTIVE' &&
+    (ccmLicense?.edition === Editions.ENTERPRISE || ccmLicense?.edition === Editions.TEAM)
+  )
+}
+
 const isDashboardsLicensed = (
   licenseInformation: Record<string, ModuleLicenseDTO> | Record<string, undefined>
 ): boolean => {
-  return isOnPrem() || isEnterpriseLicense(licenseInformation)
+  return isOnPrem() || isEnterpriseLicense(licenseInformation) || isCcmTeamLicense(licenseInformation)
 }
 
 const DashboardsPage: React.FC = ({ children }) => {

--- a/src/modules/45-dashboards/pages/__tests__/DashboardsPage.test.tsx
+++ b/src/modules/45-dashboards/pages/__tests__/DashboardsPage.test.tsx
@@ -12,7 +12,23 @@ import * as customDashboardServices from 'services/custom-dashboards'
 import * as useLicenseStore from 'framework/LicenseStore/LicenseStoreContext'
 import { LICENSE_STATE_VALUES } from 'framework/LicenseStore/licenseStoreUtil'
 import { Editions } from '@common/constants/SubscriptionTypes'
+import { ModuleLicenseDTO } from 'services/cd-ng'
 import DashboardsPage from '../DashboardsPage'
+
+const defaultLicenseObj: useLicenseStore.LicenseStoreContextProps = {
+  versionMap: {},
+  CI_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
+  FF_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
+  CCM_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
+  CD_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
+  CHAOS_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
+  STO_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
+  CV_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
+  CET_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
+  SEI_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
+  updateLicenseStore: jest.fn(),
+  licenseInformation: {}
+}
 
 const renderComponent = ({ children }: React.PropsWithChildren<unknown> = {}): RenderResult =>
   render(
@@ -32,18 +48,7 @@ describe('DashboardsPage', () => {
 
   test('it should display the banner when license edition is not enterprise', async () => {
     const licenseObj: useLicenseStore.LicenseStoreContextProps = {
-      versionMap: {},
-      CI_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
-      FF_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
-      CCM_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
-      CD_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
-      CHAOS_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
-      STO_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
-      CV_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
-      CET_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
-      SEI_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
-
-      updateLicenseStore: jest.fn(),
+      ...defaultLicenseObj,
       licenseInformation: {
         CD: {
           status: LICENSE_STATE_VALUES.ACTIVE,
@@ -66,19 +71,34 @@ describe('DashboardsPage', () => {
     expect(screen.getByText('dashboards.upgrade')).toBeInTheDocument()
   })
 
+  test('it should display the banner when license edition is team for all modules except CCM', async () => {
+    const activeTeamLicense: ModuleLicenseDTO = {
+      status: LICENSE_STATE_VALUES.ACTIVE,
+      edition: Editions.TEAM
+    }
+    const licenseObj: useLicenseStore.LicenseStoreContextProps = {
+      ...defaultLicenseObj,
+      licenseInformation: {
+        CD: { ...activeTeamLicense },
+        CI: { ...activeTeamLicense },
+        CF: { ...activeTeamLicense },
+        CV: { ...activeTeamLicense },
+        SRM: { ...activeTeamLicense },
+        STO: { ...activeTeamLicense },
+        CHAOS: { ...activeTeamLicense },
+        CET: { ...activeTeamLicense }
+      }
+    }
+    useLicenseStoreMock.mockReturnValue(licenseObj)
+
+    renderComponent()
+
+    expect(screen.getByText('dashboards.upgrade')).toBeInTheDocument()
+  })
+
   test('it should not show the banner when license is enterprise', async () => {
     const licenseObj: useLicenseStore.LicenseStoreContextProps = {
-      versionMap: {},
-      CI_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
-      FF_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
-      CCM_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
-      CD_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
-      CHAOS_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
-      STO_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
-      CV_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
-      CET_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
-      SEI_LICENSE_STATE: LICENSE_STATE_VALUES.EXPIRED,
-      updateLicenseStore: jest.fn(),
+      ...defaultLicenseObj,
       licenseInformation: {
         CD: {
           status: LICENSE_STATE_VALUES.ACTIVE,
@@ -91,6 +111,23 @@ describe('DashboardsPage', () => {
         CF: {
           status: LICENSE_STATE_VALUES.EXPIRED,
           edition: Editions.ENTERPRISE
+        }
+      }
+    }
+    useLicenseStoreMock.mockReturnValue(licenseObj)
+
+    renderComponent()
+
+    expect(screen.queryByText('dashboards.upgrade')).not.toBeInTheDocument()
+  })
+
+  test('it should not show the banner when CCM license is team', async () => {
+    const licenseObj: useLicenseStore.LicenseStoreContextProps = {
+      ...defaultLicenseObj,
+      licenseInformation: {
+        CE: {
+          status: LICENSE_STATE_VALUES.ACTIVE,
+          edition: Editions.TEAM
         }
       }
     }


### PR DESCRIPTION
### Summary

This is a small change to allow users to access dashboards when they have a CCM Team edition license on their account.
* Also some cleanup of old unused redirects.

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
