### PR TITLE
fix: [CDS-76291]: add banner to prevent user to aid in setting up the barrier

### DIFF
--- a/src/modules/10-common/strings/strings.en.yaml
+++ b/src/modules/10-common/strings/strings.en.yaml
@@ -1591,4 +1591,5 @@ billingInfo:
     addressLength: Cannot be more than 100 characters
     cityLenght: Cannot be more than 20 characters
     zipCode: Cannot be more than 10 characters
+forMoreInfo: For more info
 workflow: Workflow

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/Barrier/Barrier.module.scss
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/Barrier/Barrier.module.scss
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+.infoContainer {
+  a {
+    color: var(--primary-7) !important;
+  }
+
+  span[data-icon='info'] {
+    margin-top: 2px !important;
+  }
+}

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/Barrier/Barrier.module.scss
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/Barrier/Barrier.module.scss
@@ -5,12 +5,12 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-.infoContainer {
+.infoText {
   a {
     color: var(--primary-7) !important;
   }
+}
 
-  span[data-icon='info'] {
-    margin-top: 2px !important;
-  }
+.infoIcon {
+  margin-top: 2px !important;
 }

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/Barrier/Barrier.module.scss
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/Barrier/Barrier.module.scss
@@ -7,7 +7,7 @@
 
 .infoText {
   a {
-    color: var(--primary-7) !important;
+    color: var(--white) !important;
   }
 }
 

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/Barrier/Barrier.module.scss.d.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/Barrier/Barrier.module.scss.d.ts
@@ -1,0 +1,12 @@
+/* eslint-disable */
+/**
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ **/
+// this is an auto-generated file, do not update this manually
+declare const styles: {
+  readonly infoContainer: string
+}
+export default styles

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/Barrier/Barrier.module.scss.d.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/Barrier/Barrier.module.scss.d.ts
@@ -7,6 +7,7 @@
  **/
 // this is an auto-generated file, do not update this manually
 declare const styles: {
-  readonly infoContainer: string
+  readonly infoIcon: string
+  readonly infoText: string
 }
 export default styles

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/Barrier/Barrier.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/Barrier/Barrier.tsx
@@ -178,12 +178,13 @@ function BarrierWidget(props: BarrierProps, formikRef: StepFormikFowardRef<Barri
             <>
               <Layout.Horizontal
                 spacing={'small'}
+                background={Color.PRIMARY_5}
                 border={{ radius: 2, color: Color.GREY_200 }}
                 margin={{ bottom: 'xlarge' }}
                 padding={'medium'}
               >
-                <Icon name={'info'} className={css.infoIcon} />
-                <Text color={Color.PRIMARY_7} font={{ variation: FontVariation.H6 }} className={css.infoText}>
+                <Icon name={'info'} color={Color.WHITE} className={css.infoIcon} />
+                <Text color={Color.WHITE} font={{ variation: FontVariation.H6 }} className={css.infoText}>
                   <String stringID="pipeline.barrierStep.helpText" />
                   <a rel="noreferrer" target="_blank" href={barrierDocLink}>
                     {`[${getString('common.forMoreInfo')}]`}

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/Barrier/Barrier.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/Barrier/Barrier.tsx
@@ -74,6 +74,8 @@ import pipelineVariablesCss from '@pipeline/components/PipelineStudio/PipelineVa
 import css from './Barrier.module.scss'
 
 type BarrierData = StepElementConfig
+const infoLink =
+  'https://developer.harness.io/docs/continuous-delivery/x-platform-cd-features/cd-steps/flow-control/synchronize-deployments-using-barriers/'
 
 export interface BarrierVariableStepProps {
   initialValues: BarrierData
@@ -180,12 +182,11 @@ function BarrierWidget(props: BarrierProps, formikRef: StepFormikFowardRef<Barri
                 border={{ radius: 2, color: Color.GREY_200 }}
                 margin={{ bottom: 'xlarge' }}
                 padding={'medium'}
-                className={css.infoContainer}
               >
-                <Icon name={'info'} />
-                <Text color={Color.PRIMARY_7} font={{ variation: FontVariation.H6 }}>
+                <Icon name={'info'} className={css.infoIcon} />
+                <Text color={Color.PRIMARY_7} font={{ variation: FontVariation.H6 }} className={css.infoText}>
                   <String stringID="pipeline.barrierStep.helpText" />
-                  <a rel="noreferrer" target="_blank" href={getString('pipeline.barrierStep.infoLink')}>
+                  <a rel="noreferrer" target="_blank" href={infoLink}>
                     {`[${getString('common.forMoreInfo')}]`}
                   </a>
                 </Text>

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/Barrier/Barrier.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/Barrier/Barrier.tsx
@@ -11,10 +11,14 @@ import {
   Formik,
   FormInput,
   getMultiTypeFromValue,
+  Icon,
   IconName,
+  Layout,
   MultiTypeInputType,
-  SelectOption
+  SelectOption,
+  Text
 } from '@harness/uicore'
+import { Color, FontVariation } from '@harness/design-system'
 import * as Yup from 'yup'
 import { FormikProps, yupToFormErrors } from 'formik'
 import { defaultTo, isEmpty } from 'lodash-es'
@@ -36,7 +40,7 @@ import {
 import { SelectInputSetView } from '@pipeline/components/InputSetView/SelectInputSetView/SelectInputSetView'
 import { VariablesListTable } from '@pipeline/components/VariablesListTable/VariablesListTable'
 import { SelectConfigureOptions } from '@common/components/ConfigureOptions/SelectConfigureOptions/SelectConfigureOptions'
-import { useStrings } from 'framework/strings'
+import { String, useStrings } from 'framework/strings'
 import {
   FormMultiTypeDurationField,
   getDurationValidationSchema
@@ -67,6 +71,7 @@ import { getGitQueryParamsWithParentScope } from '@common/utils/gitSyncUtils'
 import { getNameAndIdentifierSchema } from '../StepsValidateUtils'
 import stepCss from '@pipeline/components/PipelineSteps/Steps/Steps.module.scss'
 import pipelineVariablesCss from '@pipeline/components/PipelineStudio/PipelineVariables/PipelineVariables.module.scss'
+import css from './Barrier.module.scss'
 
 type BarrierData = StepElementConfig
 
@@ -170,6 +175,22 @@ function BarrierWidget(props: BarrierProps, formikRef: StepFormikFowardRef<Barri
           setFormikRef(formikRef, formik)
           return (
             <>
+              <Layout.Horizontal
+                spacing={'small'}
+                border={{ radius: 2, color: Color.GREY_200 }}
+                margin={{ bottom: 'xlarge' }}
+                padding={'medium'}
+                className={css.infoContainer}
+              >
+                <Icon name={'info'} />
+                <Text color={Color.PRIMARY_7} font={{ variation: FontVariation.H6 }}>
+                  <String stringID="pipeline.barrierStep.helpText" />
+                  <a rel="noreferrer" target="_blank" href={getString('pipeline.barrierStep.infoLink')}>
+                    {`[${getString('common.forMoreInfo')}]`}
+                  </a>
+                </Text>
+              </Layout.Horizontal>
+
               {stepViewType !== StepViewType.Template && (
                 <div className={cx(stepCss.formGroup, stepCss.lg)}>
                   <FormInput.InputWithIdentifier inputLabel={getString('name')} isIdentifierEditable={isNewStep} />

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/Barrier/Barrier.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/Barrier/Barrier.tsx
@@ -69,13 +69,12 @@ import {
 import { getGitQueryParamsWithParentScope } from '@common/utils/gitSyncUtils'
 
 import { getNameAndIdentifierSchema } from '../StepsValidateUtils'
+import { barrierDocLink } from '../StepsHelper'
 import stepCss from '@pipeline/components/PipelineSteps/Steps/Steps.module.scss'
 import pipelineVariablesCss from '@pipeline/components/PipelineStudio/PipelineVariables/PipelineVariables.module.scss'
 import css from './Barrier.module.scss'
 
 type BarrierData = StepElementConfig
-const infoLink =
-  'https://developer.harness.io/docs/continuous-delivery/x-platform-cd-features/cd-steps/flow-control/synchronize-deployments-using-barriers/'
 
 export interface BarrierVariableStepProps {
   initialValues: BarrierData
@@ -186,7 +185,7 @@ function BarrierWidget(props: BarrierProps, formikRef: StepFormikFowardRef<Barri
                 <Icon name={'info'} className={css.infoIcon} />
                 <Text color={Color.PRIMARY_7} font={{ variation: FontVariation.H6 }} className={css.infoText}>
                   <String stringID="pipeline.barrierStep.helpText" />
-                  <a rel="noreferrer" target="_blank" href={infoLink}>
+                  <a rel="noreferrer" target="_blank" href={barrierDocLink}>
                     {`[${getString('common.forMoreInfo')}]`}
                   </a>
                 </Text>

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/Barrier/__tests__/Barrier.test.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/Barrier/__tests__/Barrier.test.tsx
@@ -28,7 +28,7 @@ describe('Barrier tests', () => {
   test('Edit stage view validations', async () => {
     const ref = React.createRef<StepFormikRef<unknown>>()
     const onUpdate = jest.fn()
-    const { container, getByText, queryByText } = render(
+    const { container, getByText, queryByText, findByText } = render(
       <TestStepWidget
         initialValues={{
           timeout: '',
@@ -45,6 +45,9 @@ describe('Barrier tests', () => {
         onUpdate={onUpdate}
       />
     )
+    const helpText = await findByText('pipeline.barrierStep.helpText')
+    expect(helpText).toBeInTheDocument()
+
     // Submit empty form
     await act(() => ref.current?.submitForm()!)
     expect(getByText('pipelineSteps.stepNameRequired')).toBeTruthy()

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/Barrier/__tests__/__snapshots__/Barrier.test.tsx.snap
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/Barrier/__tests__/__snapshots__/Barrier.test.tsx.snap
@@ -6,6 +6,41 @@ exports[`Barrier tests Edit stage- readonly: edit stage readonly 1`] = `
     class="OverlaySpinner--overlaySpinner"
   >
     <div
+      class="Layout--horizontal Layout--layout-spacing-small StyledProps--main infoContainer StyledProps--border StyledProps--border-color-grey200 StyledProps--margin-bottom-xlarge StyledProps--padding-medium"
+    >
+      <span
+        class="bp3-icon StyledProps--main"
+        data-icon="info"
+      >
+        <svg
+          height="16"
+          viewBox="0 0 12 12"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M0 6a6 6 0 1012 0A6 6 0 000 6zm.75 0a5.25 5.25 0 1010.5 0A5.25 5.25 0 00.75 6zm4.206 3.104v.646h2.682v-.646l-.836-.144V4.203H4.956v.65l.836.144V8.96zm1.846-7.352v1.03h-1.01v-1.03z"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </span>
+      <p
+        class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-primary7 StyledProps--font-variation-h6"
+      >
+        <span>
+          pipeline.barrierStep.helpText
+        </span>
+        <a
+          href="pipeline.barrierStep.infoLink"
+          rel="noreferrer"
+          target="_blank"
+        >
+          [common.forMoreInfo]
+        </a>
+      </p>
+    </div>
+    <div
       class="formGroup lg"
     >
       <div
@@ -303,6 +338,41 @@ exports[`Barrier tests Edit view with runtime input values 1`] = `
   <div
     class="OverlaySpinner--overlaySpinner"
   >
+    <div
+      class="Layout--horizontal Layout--layout-spacing-small StyledProps--main infoContainer StyledProps--border StyledProps--border-color-grey200 StyledProps--margin-bottom-xlarge StyledProps--padding-medium"
+    >
+      <span
+        class="bp3-icon StyledProps--main"
+        data-icon="info"
+      >
+        <svg
+          height="16"
+          viewBox="0 0 12 12"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M0 6a6 6 0 1012 0A6 6 0 000 6zm.75 0a5.25 5.25 0 1010.5 0A5.25 5.25 0 00.75 6zm4.206 3.104v.646h2.682v-.646l-.836-.144V4.203H4.956v.65l.836.144V8.96zm1.846-7.352v1.03h-1.01v-1.03z"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </span>
+      <p
+        class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-primary7 StyledProps--font-variation-h6"
+      >
+        <span>
+          pipeline.barrierStep.helpText
+        </span>
+        <a
+          href="pipeline.barrierStep.infoLink"
+          rel="noreferrer"
+          target="_blank"
+        >
+          [common.forMoreInfo]
+        </a>
+      </p>
+    </div>
     <div
       class="formGroup lg"
     >

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/Barrier/__tests__/__snapshots__/Barrier.test.tsx.snap
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/Barrier/__tests__/__snapshots__/Barrier.test.tsx.snap
@@ -6,10 +6,10 @@ exports[`Barrier tests Edit stage- readonly: edit stage readonly 1`] = `
     class="OverlaySpinner--overlaySpinner"
   >
     <div
-      class="Layout--horizontal Layout--layout-spacing-small StyledProps--main infoContainer StyledProps--border StyledProps--border-color-grey200 StyledProps--margin-bottom-xlarge StyledProps--padding-medium"
+      class="Layout--horizontal Layout--layout-spacing-small StyledProps--main StyledProps--border StyledProps--border-color-grey200 StyledProps--margin-bottom-xlarge StyledProps--padding-medium"
     >
       <span
-        class="bp3-icon StyledProps--main"
+        class="bp3-icon StyledProps--main infoIcon"
         data-icon="info"
       >
         <svg
@@ -26,13 +26,13 @@ exports[`Barrier tests Edit stage- readonly: edit stage readonly 1`] = `
         </svg>
       </span>
       <p
-        class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-primary7 StyledProps--font-variation-h6"
+        class="StyledProps--font StyledProps--main infoText StyledProps--color StyledProps--color-primary7 StyledProps--font-variation-h6"
       >
         <span>
           pipeline.barrierStep.helpText
         </span>
         <a
-          href="pipeline.barrierStep.infoLink"
+          href="https://developer.harness.io/docs/continuous-delivery/x-platform-cd-features/cd-steps/flow-control/synchronize-deployments-using-barriers/"
           rel="noreferrer"
           target="_blank"
         >
@@ -339,10 +339,10 @@ exports[`Barrier tests Edit view with runtime input values 1`] = `
     class="OverlaySpinner--overlaySpinner"
   >
     <div
-      class="Layout--horizontal Layout--layout-spacing-small StyledProps--main infoContainer StyledProps--border StyledProps--border-color-grey200 StyledProps--margin-bottom-xlarge StyledProps--padding-medium"
+      class="Layout--horizontal Layout--layout-spacing-small StyledProps--main StyledProps--border StyledProps--border-color-grey200 StyledProps--margin-bottom-xlarge StyledProps--padding-medium"
     >
       <span
-        class="bp3-icon StyledProps--main"
+        class="bp3-icon StyledProps--main infoIcon"
         data-icon="info"
       >
         <svg
@@ -359,13 +359,13 @@ exports[`Barrier tests Edit view with runtime input values 1`] = `
         </svg>
       </span>
       <p
-        class="StyledProps--font StyledProps--main StyledProps--color StyledProps--color-primary7 StyledProps--font-variation-h6"
+        class="StyledProps--font StyledProps--main infoText StyledProps--color StyledProps--color-primary7 StyledProps--font-variation-h6"
       >
         <span>
           pipeline.barrierStep.helpText
         </span>
         <a
-          href="pipeline.barrierStep.infoLink"
+          href="https://developer.harness.io/docs/continuous-delivery/x-platform-cd-features/cd-steps/flow-control/synchronize-deployments-using-barriers/"
           rel="noreferrer"
           target="_blank"
         >

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/Barrier/__tests__/__snapshots__/Barrier.test.tsx.snap
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/Barrier/__tests__/__snapshots__/Barrier.test.tsx.snap
@@ -6,10 +6,10 @@ exports[`Barrier tests Edit stage- readonly: edit stage readonly 1`] = `
     class="OverlaySpinner--overlaySpinner"
   >
     <div
-      class="Layout--horizontal Layout--layout-spacing-small StyledProps--main StyledProps--border StyledProps--border-color-grey200 StyledProps--margin-bottom-xlarge StyledProps--padding-medium"
+      class="Layout--horizontal Layout--layout-spacing-small StyledProps--main StyledProps--background-primary5 StyledProps--border StyledProps--border-color-grey200 StyledProps--margin-bottom-xlarge StyledProps--padding-medium"
     >
       <span
-        class="bp3-icon StyledProps--main infoIcon"
+        class="bp3-icon StyledProps--main infoIcon StyledProps--color StyledProps--color-white"
         data-icon="info"
       >
         <svg
@@ -26,7 +26,7 @@ exports[`Barrier tests Edit stage- readonly: edit stage readonly 1`] = `
         </svg>
       </span>
       <p
-        class="StyledProps--font StyledProps--main infoText StyledProps--color StyledProps--color-primary7 StyledProps--font-variation-h6"
+        class="StyledProps--font StyledProps--main infoText StyledProps--color StyledProps--color-white StyledProps--font-variation-h6"
       >
         <span>
           pipeline.barrierStep.helpText
@@ -339,10 +339,10 @@ exports[`Barrier tests Edit view with runtime input values 1`] = `
     class="OverlaySpinner--overlaySpinner"
   >
     <div
-      class="Layout--horizontal Layout--layout-spacing-small StyledProps--main StyledProps--border StyledProps--border-color-grey200 StyledProps--margin-bottom-xlarge StyledProps--padding-medium"
+      class="Layout--horizontal Layout--layout-spacing-small StyledProps--main StyledProps--background-primary5 StyledProps--border StyledProps--border-color-grey200 StyledProps--margin-bottom-xlarge StyledProps--padding-medium"
     >
       <span
-        class="bp3-icon StyledProps--main infoIcon"
+        class="bp3-icon StyledProps--main infoIcon StyledProps--color StyledProps--color-white"
         data-icon="info"
       >
         <svg
@@ -359,7 +359,7 @@ exports[`Barrier tests Edit view with runtime input values 1`] = `
         </svg>
       </span>
       <p
-        class="StyledProps--font StyledProps--main infoText StyledProps--color StyledProps--color-primary7 StyledProps--font-variation-h6"
+        class="StyledProps--font StyledProps--main infoText StyledProps--color StyledProps--color-white StyledProps--font-variation-h6"
       >
         <span>
           pipeline.barrierStep.helpText

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/StepsHelper.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/StepsHelper.ts
@@ -43,3 +43,6 @@ export const getConnectorName = (connector?: ConnectorResponse): string => {
     }` || ''
   )
 }
+
+export const barrierDocLink =
+  'https://developer.harness.io/docs/continuous-delivery/x-platform-cd-features/cd-steps/flow-control/synchronize-deployments-using-barriers/'

--- a/src/modules/70-pipeline/strings/strings.en.yaml
+++ b/src/modules/70-pipeline/strings/strings.en.yaml
@@ -93,7 +93,6 @@ barrierStep:
   barrierReferenceRequired: Barrier Reference is required
   barrierReferencePlaceholder: Select or Enter Barrier Reference
   helpText: When deploying interdependent services, coordinating the timing of component deployments is crucial. The Harness Barrier’s Step can be used to synchronize different stages and step groups in a Pipeline. These barriers work effectively when two or more parallel stages/step groups share the same barrier name, ensuring synchronized execution.
-  infoLink: https://developer.harness.io/docs/continuous-delivery/x-platform-cd-features/cd-steps/flow-control/synchronize-deployments-using-barriers/
 timeRemainingSuffix: remaining till timeout
 utilitiesStep:
   url: Enter the URL

--- a/src/modules/70-pipeline/strings/strings.en.yaml
+++ b/src/modules/70-pipeline/strings/strings.en.yaml
@@ -92,6 +92,8 @@ barrierStep:
   barrierReference: Barrier Reference
   barrierReferenceRequired: Barrier Reference is required
   barrierReferencePlaceholder: Select or Enter Barrier Reference
+  helpText: When deploying interdependent services, coordinating the timing of component deployments is crucial. The Harness Barrier’s Step can be used to synchronize different stages and step groups in a Pipeline. These barriers work effectively when two or more parallel stages/step groups share the same barrier name, ensuring synchronized execution.
+  infoLink: https://developer.harness.io/docs/continuous-delivery/x-platform-cd-features/cd-steps/flow-control/synchronize-deployments-using-barriers/
 timeRemainingSuffix: remaining till timeout
 utilitiesStep:
   url: Enter the URL

--- a/src/stringTypes.ts
+++ b/src/stringTypes.ts
@@ -397,6 +397,7 @@ export interface StringsMap {
   'common.findOutMore': string
   'common.firstGeneration': string
   'common.for': string
+  'common.forMoreInfo': string
   'common.forcedDeleteLabel': string
   'common.forcedDeleteWarning': string
   'common.freezeActiveBannerTextPrefix': string
@@ -4008,6 +4009,8 @@ export interface StringsMap {
   'pipeline.barrierStep.barrierReference': string
   'pipeline.barrierStep.barrierReferencePlaceholder': string
   'pipeline.barrierStep.barrierReferenceRequired': string
+  'pipeline.barrierStep.helpText': string
+  'pipeline.barrierStep.infoLink': string
   'pipeline.barriers.addBarrier': string
   'pipeline.barriers.flowControl': string
   'pipeline.barriers.syncBarriers': string

--- a/src/stringTypes.ts
+++ b/src/stringTypes.ts
@@ -4010,7 +4010,6 @@ export interface StringsMap {
   'pipeline.barrierStep.barrierReferencePlaceholder': string
   'pipeline.barrierStep.barrierReferenceRequired': string
   'pipeline.barrierStep.helpText': string
-  'pipeline.barrierStep.infoLink': string
   'pipeline.barriers.addBarrier': string
   'pipeline.barriers.flowControl': string
   'pipeline.barriers.syncBarriers': string


### PR DESCRIPTION
### Summary

Ticket - https://harness.atlassian.net/browse/CDS-76291
- Added banner to prevent user to aid in setting up the barrier


#### Screenshots

<img width="1728" alt="Screenshot 2023-08-11 at 3 39 27 PM" src="https://github.com/harness/harness-core-ui/assets/73639897/468452ab-c93f-4e99-82fc-b83115f0df71">



#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
