### PR TITLE
fix: [CDS-77015]: fix empty string from url query param breaking the page

### DIFF
--- a/src/modules/70-pipeline/pages/execution-list/ExecutionListFilter/ExecutionListFilter.tsx
+++ b/src/modules/70-pipeline/pages/execution-list/ExecutionListFilter/ExecutionListFilter.tsx
@@ -218,10 +218,13 @@ export function ExecutionListFilter(): React.ReactElement {
     event?: React.SyntheticEvent<HTMLElement, Event> | undefined
   ) => {
     killEvent(event)
-    updateQueryParams({
-      filterIdentifier: option.value ? option.value.toString() : undefined,
-      filters: undefined
-    })
+    updateQueryParams(
+      {
+        filterIdentifier: option.value ? option.value.toString() : undefined,
+        filters: undefined
+      },
+      { skipNulls: false, strictNullHandling: true }
+    )
     option?.value &&
       trackEvent(CDActions.ApplyAdvancedFilter, {
         category: Category.PIPELINE_EXECUTION
@@ -230,10 +233,13 @@ export function ExecutionListFilter(): React.ReactElement {
 
   const handleFilterClick = (filterIdentifier: string) => {
     if (filterIdentifier !== UNSAVED_FILTER_IDENTIFIER) {
-      updateQueryParams({
-        filterIdentifier,
-        filters: undefined
-      })
+      updateQueryParams(
+        {
+          filterIdentifier,
+          filters: undefined
+        },
+        { skipNulls: false, strictNullHandling: true }
+      )
     }
   }
 
@@ -266,7 +272,10 @@ export function ExecutionListFilter(): React.ReactElement {
         orgIdentifier
       })
       const updatedFilter = await saveOrUpdateHandler(isUpdate, requestBodyPayload)
-      updateQueryParams({ filters: updatedFilter?.filterProperties || {} })
+      updateQueryParams(
+        { filters: updatedFilter?.filterProperties || {} },
+        { skipNulls: false, strictNullHandling: true }
+      )
       refetchFilterList()
       trackEvent(CDActions.ApplyAdvancedFilter, {
         category: Category.PIPELINE_EXECUTION

--- a/src/modules/70-pipeline/pages/pipeline-list/PipelineListFilter/PipelineListFilter.tsx
+++ b/src/modules/70-pipeline/pages/pipeline-list/PipelineListFilter/PipelineListFilter.tsx
@@ -176,11 +176,14 @@ export function PipelineListFilter({ onFilterListUpdate }: PipelineListFilterPro
     event?: React.SyntheticEvent<HTMLElement, Event> | undefined
   ) => {
     killEvent(event)
-    updateQueryParams({
-      filterIdentifier: option.value ? option.value.toString() : undefined,
-      filters: undefined,
-      page: DEFAULT_PAGE_INDEX
-    })
+    updateQueryParams(
+      {
+        filterIdentifier: option.value ? option.value.toString() : undefined,
+        filters: undefined,
+        page: DEFAULT_PAGE_INDEX
+      },
+      { skipNulls: false, strictNullHandling: true }
+    )
     option?.value &&
       trackEvent(CDActions.ApplyAdvancedFilter, {
         category: Category.PIPELINE
@@ -189,11 +192,14 @@ export function PipelineListFilter({ onFilterListUpdate }: PipelineListFilterPro
 
   const handleFilterClick = (filterIdentifier: string) => {
     if (filterIdentifier !== UNSAVED_FILTER_IDENTIFIER) {
-      updateQueryParams({
-        filterIdentifier,
-        filters: undefined,
-        page: DEFAULT_PAGE_INDEX
-      })
+      updateQueryParams(
+        {
+          filterIdentifier,
+          filters: undefined,
+          page: DEFAULT_PAGE_INDEX
+        },
+        { skipNulls: false, strictNullHandling: true }
+      )
     }
   }
 
@@ -226,7 +232,10 @@ export function PipelineListFilter({ onFilterListUpdate }: PipelineListFilterPro
         orgIdentifier
       })
       const updatedFilter = await saveOrUpdateHandler(isUpdate, requestBodyPayload)
-      updateQueryParams({ filters: updatedFilter?.filterProperties || {} })
+      updateQueryParams(
+        { filters: updatedFilter?.filterProperties || {} },
+        { skipNulls: false, strictNullHandling: true }
+      )
       refetchFilterList()
       trackEvent(CDActions.ApplyAdvancedFilter, {
         category: Category.PIPELINE

--- a/src/modules/70-pipeline/utils/PipelineExecutionFilterRequestUtils.ts
+++ b/src/modules/70-pipeline/utils/PipelineExecutionFilterRequestUtils.ts
@@ -6,7 +6,7 @@
  */
 
 import type { MultiSelectOption, SelectOption } from '@harness/uicore'
-import { get, omit, startCase } from 'lodash-es'
+import { get, isArray, omit, startCase } from 'lodash-es'
 import type { PipelineExecutionFilterProperties, FilterDTO, NGTag, FilterProperties } from 'services/pipeline-ng'
 
 import { EXECUTION_STATUS } from '@pipeline/utils/statusHelpers'
@@ -227,6 +227,9 @@ export const getBuildType = (moduleProperties: {
 }
 
 export const getMultiSelectFormOptions = (values?: any[], entityName?: string): SelectOption[] | undefined => {
+  if (!isArray(values)) {
+    return
+  }
   return values?.map(item => {
     const entityValue = get(item, `${entityName}`)
     return {

--- a/src/modules/70-pipeline/utils/PipelineFilterRequestUtils.ts
+++ b/src/modules/70-pipeline/utils/PipelineFilterRequestUtils.ts
@@ -6,7 +6,7 @@
  */
 
 import type { MultiSelectOption, SelectOption } from '@harness/uicore'
-import { get, omit } from 'lodash-es'
+import { get, isArray, omit } from 'lodash-es'
 import type { PipelineFilterProperties, FilterDTO, NGTag, FilterProperties } from 'services/pipeline-ng'
 
 import type { FilterDataInterface, FilterInterface } from '@common/components/Filter/Constants'
@@ -114,6 +114,9 @@ export const createRequestBodyPayload = ({
 }
 
 export const getMultiSelectFormOptions = (values?: any[], entityName?: string): SelectOption[] | undefined => {
+  if (!isArray(values)) {
+    return
+  }
   return values?.map(item => {
     return { label: get(item, `${entityName}.name`) ?? item, value: get(item, `${entityName}.name`) ?? item }
   })


### PR DESCRIPTION
### Summary

Here, due to recent expected change in the queryparam decoder prop - `ignoreEmptyStrings` to false, we are not anymore ignoring empty strings and hence the pipeline status value was being sent as empty (when its empty from url param) to the function - `getMultiSelectFormOptions` where it was failing due typeerror.

#### Screenshots

Before:

https://github.com/harness/harness-core-ui/assets/98325173/be71de2e-8826-46f4-a477-bffdcc5e0db6

After:

https://github.com/harness/harness-core-ui/assets/98325173/16eb54ec-6ade-47f3-a02d-a8668db1cff1


#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
