### PR TITLE
feat: [PL-39612]: Updated refreshToken logic—use sessionTimeout from /accounts/<accountId> API

### DIFF
--- a/src/framework/utils/SessionToken.ts
+++ b/src/framework/utils/SessionToken.ts
@@ -5,22 +5,12 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import { get } from 'lodash-es'
 import SecureStorage from './SecureStorage'
-import { parseJwtToken } from './SessionUtils'
-
-export enum TokenTimings {
-  Expiration = 'exp',
-  Creation = 'iat'
-}
 
 export default {
   getToken: (): string => SecureStorage.get<string>('token') || '',
   username: (): string => SecureStorage.get<string>('username') || '',
   accountId: (): string => SecureStorage.get<string>('acctId') || '',
   getLastTokenSetTime: (): number | undefined => SecureStorage.get<number>('lastTokenSetTime'),
-  getLastTokenTimings: (kindOfTimings: TokenTimings): number => {
-    const token = parseJwtToken(SecureStorage.get<string>('token') || '')
-    return get(token, kindOfTimings, 0) * 1000 // to make value in milliseconds since Date.now() gives time in milliseconds to be consisent for further calculations converting it to milliseconds
-  }
+  getSessionTimeOutInMinutes: (): number | undefined => SecureStorage.get<number>('sessionTimeOutInMinutes')
 }

--- a/src/framework/utils/testUtils.ts
+++ b/src/framework/utils/testUtils.ts
@@ -10,5 +10,6 @@ import type { AppStoreContextProps } from 'framework/AppStore/AppStoreContext'
 export const defaultAppStoreTestData: AppStoreContextProps = {
   featureFlags: {},
   updateAppStore: jest.fn(),
-  currentUserInfo: { uuid: '' }
+  currentUserInfo: { uuid: '' },
+  accountInfo: {}
 }

--- a/src/modules/10-common/utils/DefaultAppStoreData.ts
+++ b/src/modules/10-common/utils/DefaultAppStoreData.ts
@@ -45,7 +45,8 @@ export const defaultAppStoreValues: Omit<AppStoreContextProps, 'updateAppStore'>
     admin: false,
     twoFactorAuthenticationEnabled: false,
     emailVerified: false
-  }
+  },
+  accountInfo: {}
 }
 
 export const communityLicenseStoreValues = {

--- a/src/modules/10-common/utils/testUtils.tsx
+++ b/src/modules/10-common/utils/testUtils.tsx
@@ -178,6 +178,7 @@ export const TestWrapper: React.FC<TestWrapperProps> = props => {
               },
               updateAppStore: () => void 0,
               currentUserInfo: { uuid: '' },
+              accountInfo: {},
               ...defaultAppStoreValues
             }}
           >


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->
JIRA: https://harness.atlassian.net/browse/PL-39612
Update refreshToken logic—now sessionTimeout is used from `/accounts/<accountId>` rather than the token itself.
This is a pre-requisite to migration of token to cookie


#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
