### PR TITLE
fix: [CDS-68796]: Retry field for jira approval and service now approval

### DIFF
--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/CustomApproval/CustomApproval.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/CustomApproval/CustomApproval.tsx
@@ -234,7 +234,7 @@ export class CustomApproval extends PipelineStep<CustomApprovalData> {
       rejectionCriteria: getDefaultCriterias(),
       approvalCriteria: getDefaultCriterias(),
       scriptTimeout: '10m',
-      retryInterval: '10s',
+      retryInterval: '1m',
       shell: customApprovalType[0].value,
       onDelegate: 'targethost',
       source: {

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/JiraApprovalDeploymentMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/JiraApprovalDeploymentMode.tsx
@@ -105,6 +105,25 @@ function FormContent(formContentProps: JiraApprovalDeploymentModeProps) {
         />
       ) : null}
 
+      {getMultiTypeFromValue(template?.spec?.retryInterval) === MultiTypeInputType.RUNTIME && (
+        <TimeoutFieldInputSetView
+          multiTypeDurationProps={{
+            configureOptionsProps: {
+              isExecutionTimeFieldDisabled: isExecutionTimeFieldDisabled(stepViewType)
+            },
+            allowableTypes,
+            expressions,
+            disabled: readonly
+          }}
+          label={getString('pipeline.customApprovalStep.retryInterval')}
+          name={`${prefix}spec.retryInterval`}
+          disabled={readonly}
+          fieldPath={'spec.retryInterval'}
+          template={template}
+          className={css.deploymentViewMedium}
+        />
+      )}
+
       {getMultiTypeFromValue(template?.spec?.approvalCriteria?.spec?.expression) === MultiTypeInputType.RUNTIME ? (
         <FormMultiTypeTextAreaField
           className={css.deploymentViewMedium}

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/JiraApprovalStepMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/JiraApprovalStepMode.tsx
@@ -28,8 +28,7 @@ import { setFormikRef, StepFormikFowardRef, StepViewType } from '@pipeline/compo
 import { useStrings } from 'framework/strings'
 import {
   FormMultiTypeDurationField,
-  getDurationValidationSchema,
-  isValidTimeString
+  getDurationValidationSchema
 } from '@common/components/MultiTypeDuration/MultiTypeDuration'
 import { useVariablesExpression } from '@pipeline/components/PipelineStudio/PiplineHooks/useVariablesExpression'
 import {
@@ -59,7 +58,13 @@ import type {
   JiraFormContentInterface,
   JiraProjectSelectOption
 } from './types'
-import { getApprovalRejectionCriteriaForInitialValues, getGenuineValue, resetForm, setIssueTypeOptions } from './helper'
+import {
+  checkIfFixedAndValidString,
+  getApprovalRejectionCriteriaForInitialValues,
+  getGenuineValue,
+  resetForm,
+  setIssueTypeOptions
+} from './helper'
 import { isApprovalStepFieldDisabled } from '../Common/ApprovalCommons'
 import { ApprovalRejectionCriteria } from '../Common/ApprovalRejectionCriteria'
 import stepCss from '@pipeline/components/PipelineSteps/Steps/Steps.module.scss'
@@ -530,10 +535,6 @@ function JiraApprovalStepMode(props: JiraApprovalStepModeProps, formikRef: StepF
       fetchStatus: true
     }
   })
-
-  const checkIfFixedAndValidString = (val: string): boolean => {
-    return getMultiTypeFromValue(val) === MultiTypeInputType.FIXED && isValidTimeString(val)
-  }
 
   return (
     <Formik<JiraApprovalData>

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/JiraApprovalStepMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/JiraApprovalStepMode.tsx
@@ -18,8 +18,7 @@ import {
   FormikForm,
   FormInput,
   getMultiTypeFromValue,
-  MultiTypeInputType,
-  parseStringToTime
+  MultiTypeInputType
 } from '@harness/uicore'
 import { Intent } from '@harness/design-system'
 import { defaultTo } from 'lodash-es'
@@ -58,15 +57,10 @@ import type {
   JiraFormContentInterface,
   JiraProjectSelectOption
 } from './types'
-import {
-  checkIfFixedAndValidString,
-  getApprovalRejectionCriteriaForInitialValues,
-  getGenuineValue,
-  resetForm,
-  setIssueTypeOptions
-} from './helper'
+import { getApprovalRejectionCriteriaForInitialValues, getGenuineValue, resetForm, setIssueTypeOptions } from './helper'
 import { isApprovalStepFieldDisabled } from '../Common/ApprovalCommons'
 import { ApprovalRejectionCriteria } from '../Common/ApprovalRejectionCriteria'
+import { isRetryIntervalGreaterThanTimeout } from '../StepsHelper'
 import stepCss from '@pipeline/components/PipelineSteps/Steps/Steps.module.scss'
 import css from './JiraApproval.module.scss'
 
@@ -539,19 +533,15 @@ function JiraApprovalStepMode(props: JiraApprovalStepModeProps, formikRef: StepF
   return (
     <Formik<JiraApprovalData>
       onSubmit={values => {
-        const timeoutString = (formikRef as React.MutableRefObject<FormikProps<JiraApprovalData>>)?.current?.values
-          ?.timeout
-        const retryIntervalString = (formikRef as React.MutableRefObject<FormikProps<JiraApprovalData>>)?.current
-          ?.values?.spec?.retryInterval
-        if (checkIfFixedAndValidString(timeoutString || '') && checkIfFixedAndValidString(retryIntervalString)) {
-          const retryInterval = parseStringToTime(retryIntervalString)
-          const timeout = parseStringToTime(timeoutString || '')
-          if (retryInterval > timeout)
-            (formikRef as React.MutableRefObject<FormikProps<JiraApprovalData>>)?.current?.setFieldError(
-              'spec.retryInterval',
-              getString('pipeline.jiraApprovalStep.validations.retryIntervalExceedingTimeout')
-            )
-        }
+        if (
+          isRetryIntervalGreaterThanTimeout(
+            (formikRef as React.MutableRefObject<FormikProps<JiraApprovalData>>)?.current?.values
+          )
+        )
+          (formikRef as React.MutableRefObject<FormikProps<JiraApprovalData>>)?.current?.setFieldError(
+            'spec.retryInterval',
+            getString('pipeline.jiraApprovalStep.validations.retryIntervalExceedingTimeout')
+          )
         onUpdate?.(values)
       }}
       formName="jiraApproval"

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/JiraApprovalStepMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/JiraApprovalStepMode.tsx
@@ -418,7 +418,15 @@ function FormContent({
           />
         )}
       </div>
-
+      <div className={cx(stepCss.formGroup, stepCss.sm)}>
+        <FormMultiTypeDurationField
+          name="spec.retryInterval"
+          label={getString('pipeline.customApprovalStep.retryInterval')}
+          multiTypeDurationProps={{ enableConfigureOptions: true, expressions, disabled: readonly, allowableTypes }}
+          className={stepCss.duration}
+          disabled={readonly}
+        />
+      </div>
       <ApprovalRejectionCriteria
         statusList={statusList}
         fieldList={fieldList}
@@ -535,6 +543,9 @@ function JiraApprovalStepMode(props: JiraApprovalStepModeProps, formikRef: StepF
         ...getNameAndIdentifierSchema(getString, stepViewType),
         timeout: getDurationValidationSchema({ minimum: '10s' }).required(getString('validation.timeout10SecMinimum')),
         spec: Yup.object().shape({
+          retryInterval: getDurationValidationSchema({ minimum: '10s' }).required(
+            getString('pipeline.customApprovalStep.validation.minimumRetryIntervalIs10Secs')
+          ),
           connectorRef: Yup.string().required(getString('pipeline.jiraApprovalStep.validations.connectorRef')),
           issueKey: Yup.string().trim().required(getString('pipeline.jiraApprovalStep.validations.issueKey')),
           approvalCriteria: Yup.object().shape({

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/__tests__/JiraApproval.test.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/__tests__/JiraApproval.test.tsx
@@ -282,7 +282,8 @@ describe('Jira Approval tests', () => {
           issueType: '',
           issueKey: '',
           approvalCriteria: getDefaultCriterias(),
-          rejectionCriteria: getDefaultCriterias()
+          rejectionCriteria: getDefaultCriterias(),
+          retryInterval: '1m'
         }
       },
       template: {
@@ -296,7 +297,8 @@ describe('Jira Approval tests', () => {
           issueType: '',
           issueKey: '',
           approvalCriteria: getDefaultCriterias(),
-          rejectionCriteria: getDefaultCriterias()
+          rejectionCriteria: getDefaultCriterias(),
+          retryInterval: '1m'
         }
       },
       viewType: StepViewType.TriggerForm

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/__tests__/JiraApproval.test.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/__tests__/JiraApproval.test.tsx
@@ -238,6 +238,7 @@ describe('Jira Approval tests', () => {
         connectorRef: 'c1d1',
         projectKey: 'pid1',
         issueKey: 'tdc-2345',
+        retryInterval: '1m',
         issueType: 'itd1',
         approvalCriteria: {
           type: 'KeyValues',

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/__tests__/JiraApprovalTestHelper.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/__tests__/JiraApprovalTestHelper.ts
@@ -27,6 +27,7 @@ export const getJiraApprovalEditModeProps = (): JiraApprovalStepModeProps => ({
     type: StepType.JiraApproval,
     identifier: '',
     spec: {
+      retryInterval: '1m',
       connectorRef: '',
       projectKey: '',
       issueKey: '',
@@ -47,6 +48,7 @@ export const getJiraApprovalEditModePropsWithConnectorId = (): JiraApprovalStepM
     type: StepType.JiraApproval,
     identifier: '',
     spec: {
+      retryInterval: '1m',
       connectorRef: 'cid',
       projectKey: '',
       issueKey: '',
@@ -71,6 +73,7 @@ export const getJiraApprovalEditModePropsWithValues = (): JiraApprovalStepModePr
     type: StepType.JiraApproval,
     identifier: '',
     spec: {
+      retryInterval: '1m',
       connectorRef: 'c1d1',
       projectKey: 'pid1',
       issueKey: 'tdc-2345',
@@ -118,6 +121,7 @@ export const getJiraApprovalDeploymentModeProps = (): JiraApprovalDeploymentMode
       projectKey: '',
       issueKey: '',
       issueType: '',
+      retryInterval: '1m',
       approvalCriteria: getDefaultCriterias(),
       rejectionCriteria: getDefaultCriterias()
     }
@@ -133,6 +137,7 @@ export const getJiraApprovalDeploymentModeProps = (): JiraApprovalDeploymentMode
         projectKey: RUNTIME_INPUT_VALUE,
         issueKey: RUNTIME_INPUT_VALUE,
         issueType: RUNTIME_INPUT_VALUE,
+        retryInterval: RUNTIME_INPUT_VALUE,
         approvalCriteria: getDefaultCriterias(),
         rejectionCriteria: getDefaultCriterias()
       }

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/__tests__/__snapshots__/JiraApproval.test.tsx.snap
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/__tests__/__snapshots__/JiraApproval.test.tsx.snap
@@ -661,6 +661,83 @@ exports[`Jira Approval fetch projects show error if failed to fetch projects 1`]
           </div>
         </div>
         <div
+          class="formGroup sm"
+        >
+          <div
+            class="bp3-form-group duration"
+            data-id="spec.retryInterval-6"
+          >
+            <label
+              class="bp3-label"
+              for="spec.retryInterval"
+            >
+              <span
+                class="Tooltip--acenter"
+                data-tooltip-id="jiraApproval_spec.retryInterval"
+              >
+                pipeline.customApprovalStep.retryInterval
+              </span>
+               
+              <span
+                class="bp3-text-muted"
+              />
+            </label>
+            <div
+              class="bp3-form-content"
+            >
+              <div
+                class="container"
+              >
+                <div
+                  class="Layout--horizontal StyledProps--main MultiTypeInput--main"
+                  style="flex-grow: 1;"
+                >
+                  <div
+                    class="bp3-input-group bp3-fill"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="spec.retryInterval"
+                      placeholder="Enter w/d/h/m/s/ms"
+                      type="text"
+                      value="1m"
+                    />
+                  </div>
+                  <span
+                    class="bp3-popover-wrapper MultiTypeInput--wrapper"
+                  >
+                    <span
+                      class="bp3-popover-target"
+                    >
+                      <button
+                        class="MultiTypeInput--btn MultiTypeInput--FIXED"
+                        data-testid="multi-type-button"
+                      >
+                        <span
+                          class="bp3-icon StyledProps--main"
+                          data-icon="fixed-input"
+                        >
+                          <svg
+                            height="12"
+                            viewBox="0 0 9 9"
+                            width="12"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                              fill="currentColor"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                    </span>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
           class="box"
         >
           <div
@@ -996,6 +1073,82 @@ exports[`Jira Approval tests Basic snapshot - deploymentform mode: jira-approval
                 </button>
               </span>
             </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="fieldAndOptions deploymentViewMedium"
+    >
+      <div
+        class="bp3-form-group"
+      >
+        <label
+          class="bp3-label"
+          for="spec.retryInterval"
+        >
+          <span
+            class="Tooltip--acenter"
+            data-tooltip-id="stepTestUtilForm_spec.retryInterval"
+          >
+            pipeline.customApprovalStep.retryInterval
+          </span>
+           
+          <span
+            class="bp3-text-muted"
+          />
+        </label>
+        <div
+          class="bp3-form-content"
+        >
+          <div
+            class="container"
+          >
+            <div
+              class="Layout--horizontal StyledProps--main MultiTypeInput--main"
+              style="flex-grow: 1;"
+            >
+              <div
+                class="bp3-input-group bp3-fill"
+              >
+                <input
+                  class="bp3-input"
+                  name="spec.retryInterval"
+                  placeholder="Enter w/d/h/m/s/ms"
+                  type="text"
+                  value="1m"
+                />
+              </div>
+              <span
+                class="bp3-popover-wrapper MultiTypeInput--wrapper"
+              >
+                <span
+                  class="bp3-popover-target"
+                >
+                  <button
+                    class="MultiTypeInput--btn MultiTypeInput--FIXED"
+                    data-testid="multi-type-button"
+                  >
+                    <span
+                      class="bp3-icon StyledProps--main"
+                      data-icon="fixed-input"
+                    >
+                      <svg
+                        height="12"
+                        viewBox="0 0 9 9"
+                        width="12"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                </span>
+              </span>
+            </div>
           </div>
         </div>
       </div>
@@ -1379,6 +1532,82 @@ exports[`Jira Approval tests Basic snapshot - inputset mode: input set with erro
                 class="FormError--error"
               >
                 pipeline.jiraApprovalStep.validations.issueKey
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="fieldAndOptions deploymentViewMedium"
+    >
+      <div
+        class="bp3-form-group"
+      >
+        <label
+          class="bp3-label"
+          for="spec.retryInterval"
+        >
+          <span
+            class="Tooltip--acenter"
+            data-tooltip-id="stepTestUtilForm_spec.retryInterval"
+          >
+            pipeline.customApprovalStep.retryInterval
+          </span>
+           
+          <span
+            class="bp3-text-muted"
+          />
+        </label>
+        <div
+          class="bp3-form-content"
+        >
+          <div
+            class="container"
+          >
+            <div
+              class="Layout--horizontal StyledProps--main MultiTypeInput--main"
+              style="flex-grow: 1;"
+            >
+              <div
+                class="bp3-input-group bp3-fill"
+              >
+                <input
+                  class="bp3-input"
+                  name="spec.retryInterval"
+                  placeholder="Enter w/d/h/m/s/ms"
+                  type="text"
+                  value="1m"
+                />
+              </div>
+              <span
+                class="bp3-popover-wrapper MultiTypeInput--wrapper"
+              >
+                <span
+                  class="bp3-popover-target"
+                >
+                  <button
+                    class="MultiTypeInput--btn MultiTypeInput--FIXED"
+                    data-testid="multi-type-button"
+                  >
+                    <span
+                      class="bp3-icon StyledProps--main"
+                      data-icon="fixed-input"
+                    >
+                      <svg
+                        height="12"
+                        viewBox="0 0 9 9"
+                        width="12"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                </span>
               </span>
             </div>
           </div>
@@ -1963,6 +2192,77 @@ exports[`Jira Approval tests Edit stage - readonly: edit stage view readonly 1`]
           </div>
         </div>
         <div
+          class="formGroup sm"
+        >
+          <div
+            class="bp3-form-group bp3-disabled duration"
+            data-id="spec.retryInterval-6"
+          >
+            <label
+              class="bp3-label"
+              for="spec.retryInterval"
+            >
+              <span
+                class="Tooltip--acenter"
+                data-tooltip-id="jiraApproval_spec.retryInterval"
+              >
+                pipeline.customApprovalStep.retryInterval
+              </span>
+               
+              <span
+                class="bp3-text-muted"
+              />
+            </label>
+            <div
+              class="bp3-form-content"
+            >
+              <div
+                class="container"
+              >
+                <div
+                  class="Layout--horizontal StyledProps--main MultiTypeInput--main MultiTypeInput--disabled"
+                  style="flex-grow: 1;"
+                >
+                  <div
+                    class="bp3-input-group bp3-disabled bp3-fill"
+                  >
+                    <input
+                      class="bp3-input"
+                      disabled=""
+                      name="spec.retryInterval"
+                      placeholder="Enter w/d/h/m/s/ms"
+                      type="text"
+                      value="1m"
+                    />
+                  </div>
+                  <button
+                    class="MultiTypeInput--btn MultiTypeInput--FIXED"
+                    data-testid="multi-type-button"
+                    disabled=""
+                  >
+                    <span
+                      class="bp3-icon StyledProps--main"
+                      data-icon="fixed-input"
+                    >
+                      <svg
+                        height="12"
+                        viewBox="0 0 9 9"
+                        width="12"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
           class="box"
         >
           <div
@@ -2310,6 +2610,82 @@ exports[`Jira Approval tests deploymentform mode - readonly: jira-approval-deplo
                 </button>
               </span>
             </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="fieldAndOptions deploymentViewMedium"
+    >
+      <div
+        class="bp3-form-group"
+      >
+        <label
+          class="bp3-label"
+          for="spec.retryInterval"
+        >
+          <span
+            class="Tooltip--acenter"
+            data-tooltip-id="stepTestUtilForm_spec.retryInterval"
+          >
+            pipeline.customApprovalStep.retryInterval
+          </span>
+           
+          <span
+            class="bp3-text-muted"
+          />
+        </label>
+        <div
+          class="bp3-form-content"
+        >
+          <div
+            class="container"
+          >
+            <div
+              class="Layout--horizontal StyledProps--main MultiTypeInput--main"
+              style="flex-grow: 1;"
+            >
+              <div
+                class="bp3-input-group bp3-fill"
+              >
+                <input
+                  class="bp3-input"
+                  name="spec.retryInterval"
+                  placeholder="Enter w/d/h/m/s/ms"
+                  type="text"
+                  value="1m"
+                />
+              </div>
+              <span
+                class="bp3-popover-wrapper MultiTypeInput--wrapper"
+              >
+                <span
+                  class="bp3-popover-target"
+                >
+                  <button
+                    class="MultiTypeInput--btn MultiTypeInput--FIXED"
+                    data-testid="multi-type-button"
+                  >
+                    <span
+                      class="bp3-icon StyledProps--main"
+                      data-icon="fixed-input"
+                    >
+                      <svg
+                        height="12"
+                        viewBox="0 0 9 9"
+                        width="12"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                </span>
+              </span>
+            </div>
           </div>
         </div>
       </div>

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/helper.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/helper.ts
@@ -16,6 +16,7 @@ import {
 } from '@pipeline/components/PipelineSteps/Steps/Common/types'
 import { getApprovalRejectionCriteriaForSubmit } from '@pipeline/components/PipelineSteps/Steps/Common/ApprovalCommons'
 import type { JiraApprovalData, JiraProjectSelectOption } from './types'
+import { isValidTimeString } from '@common/components/MultiTypeDuration/helper'
 
 export const processFormData = (values: JiraApprovalData): JiraApprovalData => {
   return {
@@ -230,4 +231,8 @@ export const handleOperatorChange = (
       onChange({ ...values, spec: { ...values.spec, conditions: tobeUpdatedConditions } })
     }
   }
+}
+
+export const checkIfFixedAndValidString = (val: string): boolean => {
+  return getMultiTypeFromValue(val) === MultiTypeInputType.FIXED && isValidTimeString(val)
 }

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/helper.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/helper.ts
@@ -15,8 +15,8 @@ import {
   ApprovalRejectionCriteriaType
 } from '@pipeline/components/PipelineSteps/Steps/Common/types'
 import { getApprovalRejectionCriteriaForSubmit } from '@pipeline/components/PipelineSteps/Steps/Common/ApprovalCommons'
-import type { JiraApprovalData, JiraProjectSelectOption } from './types'
 import { isValidTimeString } from '@common/components/MultiTypeDuration/helper'
+import type { JiraApprovalData, JiraProjectSelectOption } from './types'
 
 export const processFormData = (values: JiraApprovalData): JiraApprovalData => {
   return {

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/types.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/JiraApproval/types.ts
@@ -28,6 +28,7 @@ export interface JiraApprovalData extends StepElementConfig {
     issueKey: string
     approvalCriteria: ApprovalRejectionCriteria
     rejectionCriteria: ApprovalRejectionCriteria
+    retryInterval: string
   }
 }
 

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/ServiceNowApproval.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/ServiceNowApproval.tsx
@@ -9,7 +9,7 @@ import React from 'react'
 
 import { connect, FormikErrors, yupToFormErrors } from 'formik'
 import { getMultiTypeFromValue, IconName, MultiTypeInputType } from '@harness/uicore'
-import { defaultTo, get, isEmpty } from 'lodash-es'
+import { defaultTo, get, isEmpty, merge } from 'lodash-es'
 import * as Yup from 'yup'
 import { CompletionItemKind } from 'vscode-languageserver-types'
 import { parse } from '@common/utils/YamlHelperMethods'

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/ServiceNowApproval.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/ServiceNowApproval.tsx
@@ -67,6 +67,7 @@ export class ServiceNowApproval extends PipelineStep<ServiceNowApprovalData> {
     spec: {
       connectorRef: '',
       ticketNumber: '',
+      retryInterval: '1m',
       ticketType: '',
       approvalCriteria: getDefaultCriterias(),
       rejectionCriteria: getDefaultCriterias()
@@ -173,9 +174,11 @@ export class ServiceNowApproval extends PipelineStep<ServiceNowApprovalData> {
   validateInputSet({
     data,
     template,
-    getString
+    getString,
+    viewType
   }: ValidateInputSetProps<ServiceNowApprovalData>): FormikErrors<ServiceNowApprovalData> {
     const errors: FormikErrors<ServiceNowApprovalData> = {}
+    const isRequired = viewType === StepViewType.DeploymentForm || viewType === StepViewType.TriggerForm
 
     if (
       typeof template?.spec?.connectorRef === 'string' &&
@@ -223,6 +226,28 @@ export class ServiceNowApproval extends PipelineStep<ServiceNowApprovalData> {
         if (e instanceof Yup.ValidationError) {
           const err = yupToFormErrors(e)
           Object.assign(errors, err)
+        }
+      }
+    }
+
+    if (isRequired && getMultiTypeFromValue(template?.spec.retryInterval) === MultiTypeInputType.RUNTIME) {
+      const retryTimeoutSchema = Yup.object().shape({
+        spec: Yup.object().shape({
+          retryInterval: getDurationValidationSchema({ minimum: '10s' }).required(
+            getString?.('pipeline.customApprovalStep.validation.minimumRetryIntervalIs10Secs')
+          )
+        })
+      })
+
+      try {
+        retryTimeoutSchema.validateSync(data, { abortEarly: false })
+      } catch (validationErrorsObj) {
+        /* istanbul ignore else */
+        if (validationErrorsObj instanceof Yup.ValidationError) {
+          validationErrorsObj.inner?.forEach(valError => {
+            const err = yupToFormErrors(valError)
+            merge(errors, err)
+          })
         }
       }
     }

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/ServiceNowApprovalDeploymentMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/ServiceNowApprovalDeploymentMode.tsx
@@ -241,6 +241,25 @@ function FormContent(formContentProps: SnowApprovalDeploymentModeProps): JSX.Ele
         />
       ) : null}
 
+      {getMultiTypeFromValue(template?.spec?.retryInterval) === MultiTypeInputType.RUNTIME && (
+        <TimeoutFieldInputSetView
+          multiTypeDurationProps={{
+            configureOptionsProps: {
+              isExecutionTimeFieldDisabled: isExecutionTimeFieldDisabled(stepViewType)
+            },
+            allowableTypes,
+            expressions,
+            disabled: readonly
+          }}
+          label={getString('pipeline.customApprovalStep.retryInterval')}
+          name={`${prefix}spec.retryInterval`}
+          disabled={readonly}
+          fieldPath={'spec.retryInterval'}
+          template={template}
+          className={css.deploymentViewMedium}
+        />
+      )}
+
       {getMultiTypeFromValue(template?.spec?.approvalCriteria?.spec?.expression) === MultiTypeInputType.RUNTIME ? (
         <FormMultiTypeTextAreaField
           className={css.deploymentViewMedium}

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/ServiceNowApprovalStepMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/ServiceNowApprovalStepMode.tsx
@@ -13,8 +13,7 @@ import {
   FormInput,
   getMultiTypeFromValue,
   Layout,
-  MultiTypeInputType,
-  parseStringToTime
+  MultiTypeInputType
 } from '@harness/uicore'
 import * as Yup from 'yup'
 import type { FormikProps } from 'formik'
@@ -63,7 +62,7 @@ import { ConnectorConfigureOptions } from '@platform/connectors/components/Conne
 import { Connectors } from '@platform/connectors/constants'
 import { ServiceNowApprovalRejectionCriteria } from './ServiceNowApprovalRejectionCriteria'
 import { ServiceNowApprovalChangeWindow } from './ServiceNowApprovalChangeWindow'
-import { checkIfFixedAndValidString } from '../JiraApproval/helper'
+import { isRetryIntervalGreaterThanTimeout } from '../StepsHelper'
 import css from '@pipeline/components/PipelineSteps/Steps/ServiceNowApproval/ServiceNowApproval.module.scss'
 import stepCss from '@pipeline/components/PipelineSteps/Steps/Steps.module.scss'
 
@@ -407,19 +406,15 @@ function ServiceNowApprovalStepMode(
   return (
     <Formik<ServiceNowApprovalData>
       onSubmit={values => {
-        const timeoutString = (formikRef as React.MutableRefObject<FormikProps<ServiceNowApprovalData>>)?.current
-          ?.values?.timeout
-        const retryIntervalString = (formikRef as React.MutableRefObject<FormikProps<ServiceNowApprovalData>>)?.current
-          ?.values?.spec?.retryInterval
-        if (checkIfFixedAndValidString(timeoutString || '') && checkIfFixedAndValidString(retryIntervalString)) {
-          const retryInterval = parseStringToTime(retryIntervalString)
-          const timeout = parseStringToTime(timeoutString || '')
-          if (retryInterval > timeout)
-            (formikRef as React.MutableRefObject<FormikProps<ServiceNowApprovalData>>)?.current?.setFieldError(
-              'spec.retryInterval',
-              getString('pipeline.jiraApprovalStep.validations.retryIntervalExceedingTimeout')
-            )
-        }
+        if (
+          isRetryIntervalGreaterThanTimeout(
+            (formikRef as React.MutableRefObject<FormikProps<ServiceNowApprovalData>>)?.current?.values
+          )
+        )
+          (formikRef as React.MutableRefObject<FormikProps<ServiceNowApprovalData>>)?.current?.setFieldError(
+            'spec.retryInterval',
+            getString('pipeline.jiraApprovalStep.validations.retryIntervalExceedingTimeout')
+          )
         onUpdate?.(values)
       }}
       formName="serviceNowApproval"

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/ServiceNowApprovalStepMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/ServiceNowApprovalStepMode.tsx
@@ -312,6 +312,15 @@ function FormContent({
             />
           )}
         </div>
+        <div className={cx(stepCss.formGroup, stepCss.sm)}>
+          <FormMultiTypeDurationField
+            name="spec.retryInterval"
+            label={getString('pipeline.customApprovalStep.retryInterval')}
+            multiTypeDurationProps={{ enableConfigureOptions: true, expressions, disabled: readonly, allowableTypes }}
+            className={stepCss.duration}
+            disabled={readonly}
+          />
+        </div>
         <ServiceNowApprovalRejectionCriteria
           fieldList={fieldList}
           title={getString('pipeline.approvalCriteria.approvalCriteria')}
@@ -408,6 +417,9 @@ function ServiceNowApprovalStepMode(
           connectorRef: ConnectorRefSchema(getString, {
             requiredErrorMsg: getString('pipeline.serviceNowApprovalStep.validations.connectorRef')
           }),
+          retryInterval: getDurationValidationSchema({ minimum: '10s' }).required(
+            getString('pipeline.customApprovalStep.validation.minimumRetryIntervalIs10Secs')
+          ),
           ticketType: Yup.string().required(getString('pipeline.serviceNowApprovalStep.validations.ticketType')),
           ticketNumber: Yup.string().required(getString('pipeline.serviceNowApprovalStep.validations.issueNumber')),
           approvalCriteria: Yup.object().shape({

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/ServiceNowApprovalStepMode.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/ServiceNowApprovalStepMode.tsx
@@ -63,9 +63,9 @@ import { ConnectorConfigureOptions } from '@platform/connectors/components/Conne
 import { Connectors } from '@platform/connectors/constants'
 import { ServiceNowApprovalRejectionCriteria } from './ServiceNowApprovalRejectionCriteria'
 import { ServiceNowApprovalChangeWindow } from './ServiceNowApprovalChangeWindow'
+import { checkIfFixedAndValidString } from '../JiraApproval/helper'
 import css from '@pipeline/components/PipelineSteps/Steps/ServiceNowApproval/ServiceNowApproval.module.scss'
 import stepCss from '@pipeline/components/PipelineSteps/Steps/Steps.module.scss'
-import { checkIfFixedAndValidString } from '../JiraApproval/helper'
 
 const fetchingTicketTypesPlaceholder: StringKeys = 'pipeline.serviceNowApprovalStep.fetchingTicketTypesPlaceholder'
 

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/__test__/ServiceNowApproval.test.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/__test__/ServiceNowApproval.test.tsx
@@ -225,6 +225,7 @@ describe('ServiceNow Approval tests', () => {
         connectorRef: 'c1d1',
         ticketNumber: 'itd1',
         ticketType: 'INCIDENT',
+        retryInterval: '1m',
         approvalCriteria: {
           type: 'KeyValues',
           spec: {

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/__test__/ServiceNowApproval.test.tsx
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/__test__/ServiceNowApproval.test.tsx
@@ -271,7 +271,8 @@ describe('ServiceNow Approval tests', () => {
           ticketType: '',
           ticketNumber: '',
           approvalCriteria: getDefaultCriterias(),
-          rejectionCriteria: getDefaultCriterias()
+          rejectionCriteria: getDefaultCriterias(),
+          retryInterval: '1m'
         }
       },
       template: {
@@ -284,7 +285,8 @@ describe('ServiceNow Approval tests', () => {
           ticketType: '',
           ticketNumber: '',
           approvalCriteria: getDefaultCriterias(),
-          rejectionCriteria: getDefaultCriterias()
+          rejectionCriteria: getDefaultCriterias(),
+          retryInterval: '1m'
         }
       },
       viewType: StepViewType.TriggerForm

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/__test__/ServiceNowApprovalTestHelper.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/__test__/ServiceNowApprovalTestHelper.ts
@@ -28,6 +28,7 @@ export const getServiceNowApprovalEditModeProps = (): ServiceNowApprovalStepMode
     spec: {
       connectorRef: '',
       ticketType: '',
+      retryInterval: '1m',
       ticketNumber: '',
       approvalCriteria: getDefaultCriterias(),
       rejectionCriteria: getDefaultCriterias()
@@ -47,6 +48,7 @@ export const getServiceNowApprovalEditModePropsWithValues = (): ServiceNowApprov
     spec: {
       connectorRef: 'c1d1',
       ticketType: 'INCIDENT',
+      retryInterval: '1m',
       ticketNumber: 'itd1',
       approvalCriteria: {
         type: ApprovalRejectionCriteriaType.KeyValues,
@@ -88,6 +90,7 @@ export const getServiceNowApprovalDeploymentModeProps = (): SnowApprovalDeployme
     identifier: '',
     spec: {
       connectorRef: '',
+      retryInterval: '1m',
       ticketType: '',
       ticketNumber: '',
       approvalCriteria: getDefaultCriterias(),
@@ -102,6 +105,7 @@ export const getServiceNowApprovalDeploymentModeProps = (): SnowApprovalDeployme
       identifier: '',
       spec: {
         connectorRef: RUNTIME_INPUT_VALUE,
+        retryInterval: RUNTIME_INPUT_VALUE,
         ticketType: RUNTIME_INPUT_VALUE,
         ticketNumber: RUNTIME_INPUT_VALUE,
         changeWindow: {

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/__test__/__snapshots__/ServiceNowApproval.test.tsx.snap
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/__test__/__snapshots__/ServiceNowApproval.test.tsx.snap
@@ -274,6 +274,82 @@ exports[`ServiceNow Approval tests Basic snapshot - deploymentform mode: service
       </div>
     </div>
     <div
+      class="fieldAndOptions deploymentViewMedium"
+    >
+      <div
+        class="bp3-form-group"
+      >
+        <label
+          class="bp3-label"
+          for="spec.retryInterval"
+        >
+          <span
+            class="Tooltip--acenter"
+            data-tooltip-id="stepTestUtilForm_spec.retryInterval"
+          >
+            pipeline.customApprovalStep.retryInterval
+          </span>
+           
+          <span
+            class="bp3-text-muted"
+          />
+        </label>
+        <div
+          class="bp3-form-content"
+        >
+          <div
+            class="container"
+          >
+            <div
+              class="Layout--horizontal StyledProps--main MultiTypeInput--main"
+              style="flex-grow: 1;"
+            >
+              <div
+                class="bp3-input-group bp3-fill"
+              >
+                <input
+                  class="bp3-input"
+                  name="spec.retryInterval"
+                  placeholder="Enter w/d/h/m/s/ms"
+                  type="text"
+                  value="1m"
+                />
+              </div>
+              <span
+                class="bp3-popover-wrapper MultiTypeInput--wrapper"
+              >
+                <span
+                  class="bp3-popover-target"
+                >
+                  <button
+                    class="MultiTypeInput--btn MultiTypeInput--FIXED"
+                    data-testid="multi-type-button"
+                  >
+                    <span
+                      class="bp3-icon StyledProps--main"
+                      data-icon="fixed-input"
+                    >
+                      <svg
+                        height="12"
+                        viewBox="0 0 9 9"
+                        width="12"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
       class="bp3-form-group deploymentViewMedium"
     >
       <label
@@ -934,6 +1010,82 @@ exports[`ServiceNow Approval tests Basic snapshot - inputset mode: input set wit
                 class="FormError--error"
               >
                 pipeline.serviceNowApprovalStep.validations.issueNumber
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="fieldAndOptions deploymentViewMedium"
+    >
+      <div
+        class="bp3-form-group"
+      >
+        <label
+          class="bp3-label"
+          for="spec.retryInterval"
+        >
+          <span
+            class="Tooltip--acenter"
+            data-tooltip-id="stepTestUtilForm_spec.retryInterval"
+          >
+            pipeline.customApprovalStep.retryInterval
+          </span>
+           
+          <span
+            class="bp3-text-muted"
+          />
+        </label>
+        <div
+          class="bp3-form-content"
+        >
+          <div
+            class="container"
+          >
+            <div
+              class="Layout--horizontal StyledProps--main MultiTypeInput--main"
+              style="flex-grow: 1;"
+            >
+              <div
+                class="bp3-input-group bp3-fill"
+              >
+                <input
+                  class="bp3-input"
+                  name="spec.retryInterval"
+                  placeholder="Enter w/d/h/m/s/ms"
+                  type="text"
+                  value="1m"
+                />
+              </div>
+              <span
+                class="bp3-popover-wrapper MultiTypeInput--wrapper"
+              >
+                <span
+                  class="bp3-popover-target"
+                >
+                  <button
+                    class="MultiTypeInput--btn MultiTypeInput--FIXED"
+                    data-testid="multi-type-button"
+                  >
+                    <span
+                      class="bp3-icon StyledProps--main"
+                      data-icon="fixed-input"
+                    >
+                      <svg
+                        height="12"
+                        viewBox="0 0 9 9"
+                        width="12"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                </span>
               </span>
             </div>
           </div>
@@ -1614,6 +1766,77 @@ exports[`ServiceNow Approval tests Edit stage - readonly: edit stage view readon
                     </svg>
                   </span>
                 </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="formGroup sm"
+        >
+          <div
+            class="bp3-form-group bp3-disabled duration"
+            data-id="spec.retryInterval-5"
+          >
+            <label
+              class="bp3-label"
+              for="spec.retryInterval"
+            >
+              <span
+                class="Tooltip--acenter"
+                data-tooltip-id="serviceNowApproval_spec.retryInterval"
+              >
+                pipeline.customApprovalStep.retryInterval
+              </span>
+               
+              <span
+                class="bp3-text-muted"
+              />
+            </label>
+            <div
+              class="bp3-form-content"
+            >
+              <div
+                class="container"
+              >
+                <div
+                  class="Layout--horizontal StyledProps--main MultiTypeInput--main MultiTypeInput--disabled"
+                  style="flex-grow: 1;"
+                >
+                  <div
+                    class="bp3-input-group bp3-disabled bp3-fill"
+                  >
+                    <input
+                      class="bp3-input"
+                      disabled=""
+                      name="spec.retryInterval"
+                      placeholder="Enter w/d/h/m/s/ms"
+                      type="text"
+                      value="1m"
+                    />
+                  </div>
+                  <button
+                    class="MultiTypeInput--btn MultiTypeInput--FIXED"
+                    data-testid="multi-type-button"
+                    disabled=""
+                  >
+                    <span
+                      class="bp3-icon StyledProps--main"
+                      data-icon="fixed-input"
+                    >
+                      <svg
+                        height="12"
+                        viewBox="0 0 9 9"
+                        width="12"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -2337,6 +2560,83 @@ exports[`ServiceNow Approval tests Open a saved serviceNow approval step - edit 
           </div>
         </div>
         <div
+          class="formGroup sm"
+        >
+          <div
+            class="bp3-form-group duration"
+            data-id="spec.retryInterval-5"
+          >
+            <label
+              class="bp3-label"
+              for="spec.retryInterval"
+            >
+              <span
+                class="Tooltip--acenter"
+                data-tooltip-id="serviceNowApproval_spec.retryInterval"
+              >
+                pipeline.customApprovalStep.retryInterval
+              </span>
+               
+              <span
+                class="bp3-text-muted"
+              />
+            </label>
+            <div
+              class="bp3-form-content"
+            >
+              <div
+                class="container"
+              >
+                <div
+                  class="Layout--horizontal StyledProps--main MultiTypeInput--main"
+                  style="flex-grow: 1;"
+                >
+                  <div
+                    class="bp3-input-group bp3-fill"
+                  >
+                    <input
+                      class="bp3-input"
+                      name="spec.retryInterval"
+                      placeholder="Enter w/d/h/m/s/ms"
+                      type="text"
+                      value="1m"
+                    />
+                  </div>
+                  <span
+                    class="bp3-popover-wrapper MultiTypeInput--wrapper"
+                  >
+                    <span
+                      class="bp3-popover-target"
+                    >
+                      <button
+                        class="MultiTypeInput--btn MultiTypeInput--FIXED"
+                        data-testid="multi-type-button"
+                      >
+                        <span
+                          class="bp3-icon StyledProps--main"
+                          data-icon="fixed-input"
+                        >
+                          <svg
+                            height="12"
+                            viewBox="0 0 9 9"
+                            width="12"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                              fill="currentColor"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                    </span>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
           class="box"
         >
           <div
@@ -2485,7 +2785,7 @@ exports[`ServiceNow Approval tests Open a saved serviceNow approval step - edit 
                   </div>
                   <div
                     class="bp3-form-group"
-                    data-id="spec.approvalCriteria.spec.conditions[0].operator-6"
+                    data-id="spec.approvalCriteria.spec.conditions[0].operator-7"
                   >
                     <div
                       class="bp3-form-content"
@@ -2538,7 +2838,7 @@ exports[`ServiceNow Approval tests Open a saved serviceNow approval step - edit 
                   </div>
                   <div
                     class="bp3-form-group"
-                    data-id="spec.approvalCriteria.spec.conditions[0].value-7"
+                    data-id="spec.approvalCriteria.spec.conditions[0].value-8"
                   >
                     
                     <div
@@ -2680,7 +2980,7 @@ exports[`ServiceNow Approval tests Open a saved serviceNow approval step - edit 
                   </div>
                   <div
                     class="bp3-form-group"
-                    data-id="spec.approvalCriteria.spec.conditions[1].operator-9"
+                    data-id="spec.approvalCriteria.spec.conditions[1].operator-10"
                   >
                     <div
                       class="bp3-form-content"
@@ -2733,7 +3033,7 @@ exports[`ServiceNow Approval tests Open a saved serviceNow approval step - edit 
                   </div>
                   <div
                     class="bp3-form-group"
-                    data-id="spec.approvalCriteria.spec.conditions[1].value-10"
+                    data-id="spec.approvalCriteria.spec.conditions[1].value-11"
                   >
                     
                     <div
@@ -3162,6 +3462,82 @@ exports[`ServiceNow Approval tests deploymentform mode - readonly: serviceNow-ap
                 </button>
               </span>
             </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="fieldAndOptions deploymentViewMedium"
+    >
+      <div
+        class="bp3-form-group"
+      >
+        <label
+          class="bp3-label"
+          for="spec.retryInterval"
+        >
+          <span
+            class="Tooltip--acenter"
+            data-tooltip-id="stepTestUtilForm_spec.retryInterval"
+          >
+            pipeline.customApprovalStep.retryInterval
+          </span>
+           
+          <span
+            class="bp3-text-muted"
+          />
+        </label>
+        <div
+          class="bp3-form-content"
+        >
+          <div
+            class="container"
+          >
+            <div
+              class="Layout--horizontal StyledProps--main MultiTypeInput--main"
+              style="flex-grow: 1;"
+            >
+              <div
+                class="bp3-input-group bp3-fill"
+              >
+                <input
+                  class="bp3-input"
+                  name="spec.retryInterval"
+                  placeholder="Enter w/d/h/m/s/ms"
+                  type="text"
+                  value="1m"
+                />
+              </div>
+              <span
+                class="bp3-popover-wrapper MultiTypeInput--wrapper"
+              >
+                <span
+                  class="bp3-popover-target"
+                >
+                  <button
+                    class="MultiTypeInput--btn MultiTypeInput--FIXED"
+                    data-testid="multi-type-button"
+                  >
+                    <span
+                      class="bp3-icon StyledProps--main"
+                      data-icon="fixed-input"
+                    >
+                      <svg
+                        height="12"
+                        viewBox="0 0 9 9"
+                        width="12"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M5.61 7.55c.62-.7.3-1.42.18-2.35a.32.32 0 01.1-.29l1.43-1.42a.76.76 0 01.28-.15c.39-.1 1 0 1.28-.29a.34.34 0 000-.51L6.46.12a.33.33 0 00-.52 0c-.28.29-.2.9-.28 1.3a.53.53 0 01-.13.23L4.09 3.12a.29.29 0 01-.28.09c-.89-.11-1.6-.49-2.27.11-.29.26-.29.43 0 .7l1.31 1.34.15.16-.15.15-2.7 2.69a.36.36 0 000 .54.36.36 0 00.54-.05l2.63-2.68.17-.17.17.16c.45.46.9.91 1.36 1.36.21.21.42.22.59.03z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                </span>
+              </span>
+            </div>
           </div>
         </div>
       </div>

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/types.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/ServiceNowApproval/types.ts
@@ -28,6 +28,7 @@ export interface ServiceNowApprovalData extends StepElementConfig {
     connectorRef: string | SelectOption
     ticketType: string | ServiceNowTicketTypeSelectOption
     ticketNumber: string
+    retryInterval: string
     approvalCriteria: ApprovalRejectionCriteria
     rejectionCriteria: ApprovalRejectionCriteria
     changeWindow?: {

--- a/src/modules/70-pipeline/components/PipelineSteps/Steps/StepsHelper.ts
+++ b/src/modules/70-pipeline/components/PipelineSteps/Steps/StepsHelper.ts
@@ -5,8 +5,12 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
+import { parseStringToTime } from '@harness/uicore'
 import { Scope } from '@common/interfaces/SecretsInterface'
 import type { ConnectorResponse } from 'services/cd-ng'
+import { checkIfFixedAndValidString } from './JiraApproval/helper'
+import { JiraApprovalData } from './JiraApproval/types'
+import { ServiceNowApprovalData } from './ServiceNowApproval/types'
 
 export const getConnectorValue = (connector?: ConnectorResponse): string => {
   const connectorIdentifier = connector?.connector?.identifier
@@ -46,3 +50,14 @@ export const getConnectorName = (connector?: ConnectorResponse): string => {
 
 export const barrierDocLink =
   'https://developer.harness.io/docs/continuous-delivery/x-platform-cd-features/cd-steps/flow-control/synchronize-deployments-using-barriers/'
+
+export function isRetryIntervalGreaterThanTimeout(formikValue: JiraApprovalData | ServiceNowApprovalData): boolean {
+  const timeoutString = formikValue?.timeout
+  const retryIntervalString = formikValue?.spec?.retryInterval
+  if (checkIfFixedAndValidString(timeoutString || '') && checkIfFixedAndValidString(retryIntervalString)) {
+    const retryInterval = parseStringToTime(retryIntervalString)
+    const timeout = parseStringToTime(timeoutString || '')
+    if (retryInterval > timeout) return true
+  }
+  return false
+}

--- a/src/modules/70-pipeline/strings/strings.en.yaml
+++ b/src/modules/70-pipeline/strings/strings.en.yaml
@@ -237,6 +237,7 @@ jiraApprovalStep:
       in: '{{ key }} is in'
       not_in: '{{ key }} is not in'
   validations:
+    retryIntervalExceedingTimeout: Retry interval should not be more than timeout
     connectorRef: Jira Connector is required
     project: '{{$.common.validation.projectIsRequired}}'
     issueKey: Issue Key is required

--- a/src/stringTypes.ts
+++ b/src/stringTypes.ts
@@ -4587,6 +4587,7 @@ export interface StringsMap {
   'pipeline.jiraApprovalStep.validations.issueType': string
   'pipeline.jiraApprovalStep.validations.project': string
   'pipeline.jiraApprovalStep.validations.requiredField': string
+  'pipeline.jiraApprovalStep.validations.retryIntervalExceedingTimeout': string
   'pipeline.jiraCreateStep.addFields': string
   'pipeline.jiraCreateStep.descriptionPlaceholder': string
   'pipeline.jiraCreateStep.fetchingFields': string


### PR DESCRIPTION
### Summary
ticket 
https://harness.atlassian.net/browse/CDS-68797
https://harness.atlassian.net/browse/CDS-68796
<!-- ✍️ A clear and concise description...-->

#### Screenshots
<img width="507" alt="image" src="https://github.com/harness/harness-core-ui/assets/96036463/06ff734f-754e-469d-89d5-43e0feb57723">

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
