### PR TITLE
feat: [SRM-15184]: adding support for Tabs url for monitored service configurations Tabs.

### DIFF
--- a/src/modules/85-cv/components/PipelineSteps/AnalyzeDeploymentImpact/components/AnalyzeDeploymentImpactWidget/components/AnalyzeDeploymentImpactWidgetSections/components/ConfiguredMonitoredService/components/AnalyseStepHealthSourcesList/AnalyseStepHealthSourcesList.tsx
+++ b/src/modules/85-cv/components/PipelineSteps/AnalyzeDeploymentImpact/components/AnalyzeDeploymentImpactWidget/components/AnalyzeDeploymentImpactWidgetSections/components/ConfiguredMonitoredService/components/AnalyseStepHealthSourcesList/AnalyseStepHealthSourcesList.tsx
@@ -18,6 +18,7 @@ import { getCVMonitoringServicesSearchParam } from '@cv/utils/CommonUtils'
 import ConfigureMonitoredServiceDetails from '../ConfigureMonitoredServiceDetails/ConfigureMonitoredServiceDetails'
 import DetailNotPresent from '../DetailNotPresent/DetailNotPresent'
 import css from './AnalyseStepHealthSourceList.module.scss'
+import { MonitoredServiceConfigurationsTabsEnum } from '@cv/pages/monitored-service/components/Configurations/components/Service/components/CommonMonitoredServiceConfigurations/CommonMonitoredServiceConfigurations.constants'
 
 interface AnalyseStepHealthSourcesListProps {
   healthSourcesList: HealthSource[]
@@ -98,7 +99,10 @@ export default function AnalyseStepHealthSourcesList(props: AnalyseStepHealthSou
           projectIdentifier,
           identifier,
           module: 'cv'
-        })}${getCVMonitoringServicesSearchParam({ tab: MonitoredServiceEnum.Configurations })}`}
+        })}${getCVMonitoringServicesSearchParam({
+          tab: MonitoredServiceEnum.Configurations,
+          subTab: MonitoredServiceConfigurationsTabsEnum.HEALTH_SOURCE
+        })}`}
         detailToConfigureText={'Configure Health Source'}
         refetchDetails={fetchMonitoredServiceData}
       />

--- a/src/modules/85-cv/components/PipelineSteps/AnalyzeDeploymentImpact/components/AnalyzeDeploymentImpactWidget/components/AnalyzeDeploymentImpactWidgetSections/components/ConfiguredMonitoredService/components/AnalyseStepHealthSourcesList/AnalyseStepHealthSourcesList.tsx
+++ b/src/modules/85-cv/components/PipelineSteps/AnalyzeDeploymentImpact/components/AnalyzeDeploymentImpactWidget/components/AnalyzeDeploymentImpactWidgetSections/components/ConfiguredMonitoredService/components/AnalyseStepHealthSourcesList/AnalyseStepHealthSourcesList.tsx
@@ -15,10 +15,10 @@ import { ProjectPathProps } from '@common/interfaces/RouteInterfaces'
 import routes from '@common/RouteDefinitions'
 import { MonitoredServiceEnum } from '@cv/pages/monitored-service/MonitoredServicePage.constants'
 import { getCVMonitoringServicesSearchParam } from '@cv/utils/CommonUtils'
+import { MonitoredServiceConfigurationsTabsEnum } from '@cv/pages/monitored-service/components/Configurations/components/Service/components/CommonMonitoredServiceConfigurations/CommonMonitoredServiceConfigurations.constants'
 import ConfigureMonitoredServiceDetails from '../ConfigureMonitoredServiceDetails/ConfigureMonitoredServiceDetails'
 import DetailNotPresent from '../DetailNotPresent/DetailNotPresent'
 import css from './AnalyseStepHealthSourceList.module.scss'
-import { MonitoredServiceConfigurationsTabsEnum } from '@cv/pages/monitored-service/components/Configurations/components/Service/components/CommonMonitoredServiceConfigurations/CommonMonitoredServiceConfigurations.constants'
 
 interface AnalyseStepHealthSourcesListProps {
   healthSourcesList: HealthSource[]

--- a/src/modules/85-cv/components/PipelineSteps/AnalyzeDeploymentImpact/components/AnalyzeDeploymentImpactWidget/components/AnalyzeDeploymentImpactWidgetSections/components/ConfiguredMonitoredService/components/AnalyseStepNotifications/AnalyseStepNotifications.tsx
+++ b/src/modules/85-cv/components/PipelineSteps/AnalyzeDeploymentImpact/components/AnalyzeDeploymentImpactWidget/components/AnalyzeDeploymentImpactWidgetSections/components/ConfiguredMonitoredService/components/AnalyseStepNotifications/AnalyseStepNotifications.tsx
@@ -20,6 +20,7 @@ import NotificationDetails from './components/NotificationDetails'
 import { INITIAL_PAGE_NUMBER } from './AnalyseStepNotifications.constants'
 import { getValidNotifications } from './AnalyseStepNotifications.utils'
 import css from './AnalyseStepNotifications.module.scss'
+import { MonitoredServiceConfigurationsTabsEnum } from '@cv/pages/monitored-service/components/Configurations/components/Service/components/CommonMonitoredServiceConfigurations/CommonMonitoredServiceConfigurations.constants'
 
 interface AnalyseStepNotificationsProps {
   identifier: string
@@ -142,7 +143,10 @@ export default function AnalyseStepNotifications(props: AnalyseStepNotifications
               projectIdentifier,
               identifier,
               module: 'cv'
-            })}${getCVMonitoringServicesSearchParam({ tab: MonitoredServiceEnum.Configurations })}`}
+            })}${getCVMonitoringServicesSearchParam({
+              tab: MonitoredServiceEnum.Configurations,
+              subTab: MonitoredServiceConfigurationsTabsEnum.NOTIFICATIONS
+            })}`}
             detailToConfigureText={getString('cv.analyzeStep.notifications.configureNotification')}
             refetchDetails={getNotifications}
           />

--- a/src/modules/85-cv/components/PipelineSteps/AnalyzeDeploymentImpact/components/AnalyzeDeploymentImpactWidget/components/AnalyzeDeploymentImpactWidgetSections/components/ConfiguredMonitoredService/components/AnalyseStepNotifications/AnalyseStepNotifications.tsx
+++ b/src/modules/85-cv/components/PipelineSteps/AnalyzeDeploymentImpact/components/AnalyzeDeploymentImpactWidget/components/AnalyzeDeploymentImpactWidgetSections/components/ConfiguredMonitoredService/components/AnalyseStepNotifications/AnalyseStepNotifications.tsx
@@ -13,6 +13,7 @@ import { getCVMonitoringServicesSearchParam, getErrorMessage } from '@cv/utils/C
 import { MonitoredServiceEnum } from '@cv/pages/monitored-service/MonitoredServicePage.constants'
 import { killEvent } from '@common/utils/eventUtils'
 import { useStrings } from 'framework/strings'
+import { MonitoredServiceConfigurationsTabsEnum } from '@cv/pages/monitored-service/components/Configurations/components/Service/components/CommonMonitoredServiceConfigurations/CommonMonitoredServiceConfigurations.constants'
 import ConfigureMonitoredServiceDetails from '../ConfigureMonitoredServiceDetails/ConfigureMonitoredServiceDetails'
 import DetailNotPresent from '../DetailNotPresent/DetailNotPresent'
 import { AnalyseStepNotificationsData } from './AnalyseStepNotifications.types'
@@ -20,7 +21,6 @@ import NotificationDetails from './components/NotificationDetails'
 import { INITIAL_PAGE_NUMBER } from './AnalyseStepNotifications.constants'
 import { getValidNotifications } from './AnalyseStepNotifications.utils'
 import css from './AnalyseStepNotifications.module.scss'
-import { MonitoredServiceConfigurationsTabsEnum } from '@cv/pages/monitored-service/components/Configurations/components/Service/components/CommonMonitoredServiceConfigurations/CommonMonitoredServiceConfigurations.constants'
 
 interface AnalyseStepNotificationsProps {
   identifier: string

--- a/src/modules/85-cv/pages/monitored-service/components/Configurations/components/Service/components/CommonMonitoredServiceConfigurations/CommonMonitoredServiceConfigurations.constants.ts
+++ b/src/modules/85-cv/pages/monitored-service/components/Configurations/components/Service/components/CommonMonitoredServiceConfigurations/CommonMonitoredServiceConfigurations.constants.ts
@@ -1,0 +1,8 @@
+export enum MonitoredServiceConfigurationsTabsEnum {
+  MONITORED_SERVICE_OVERVIEW = 'monitoredServiceOverview',
+  HEALTH_SOURCE = 'healthSource',
+  CHANGE_SOURCE = 'changeSource',
+  DEPENDENCIES = 'Dependencies',
+  NOTIFICATIONS = 'notifications',
+  AGENT_CONFIG = 'agentConfig'
+}

--- a/src/modules/85-cv/pages/monitored-service/components/Configurations/components/Service/components/CommonMonitoredServiceConfigurations/CommonMonitoredServiceConfigurations.tsx
+++ b/src/modules/85-cv/pages/monitored-service/components/Configurations/components/Service/components/CommonMonitoredServiceConfigurations/CommonMonitoredServiceConfigurations.tsx
@@ -5,15 +5,13 @@
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
  */
 
-import { Container, Tab, Tabs, Views } from '@harness/uicore'
+import { Container, Tab, Tabs } from '@harness/uicore'
 import React from 'react'
 import { FormikContextType, useFormikContext } from 'formik'
-import { useHistory, useParams } from 'react-router-dom'
 import type { ChangeSourceDTO, MonitoredServiceDTO } from 'services/cv'
 import type { MonitoredServiceConfig } from '@cv/components/MonitoredServiceListWidget/MonitoredServiceListWidget.types'
 import { PermissionIdentifier } from '@rbac/interfaces/PermissionIdentifier'
 import SaveAndDiscardButton from '@cv/components/SaveAndDiscardButton/SaveAndDiscardButton'
-import type { ProjectPathProps } from '@common/interfaces/RouteInterfaces'
 import { ResourceType } from '@rbac/interfaces/ResourceType'
 import { isUpdated, showDependencies } from '@cv/pages/monitored-service/components/Configurations/Configurations.utils'
 import { useStrings } from 'framework/strings'
@@ -24,7 +22,6 @@ import { CETAgentConfig } from '@cet/pages/CETAgentConfig'
 import { ModuleName } from 'framework/types/ModuleName'
 import { getSearchString } from '@cv/utils/CommonUtils'
 import routes from '@common/RouteDefinitions'
-import { useQueryParams } from '@common/hooks'
 import { MonitoredServiceEnum } from '@cv/pages/monitored-service/MonitoredServicePage.constants'
 import {
   getIsAgentConfigSectionHidden,

--- a/src/modules/85-cv/utils/CommonUtils.ts
+++ b/src/modules/85-cv/utils/CommonUtils.ts
@@ -31,6 +31,7 @@ import { formatDatetoLocale } from '@common/utils/dateUtils'
 import { getScopedValueFromDTO } from '@common/components/EntityReference/EntityReference.types'
 import { ChangeSourceCategoryName } from '@cv/pages/ChangeSource/ChangeSourceDrawer/ChangeSourceDrawer.constants'
 import { DeploymentImpactAnalysis } from '@cv/pages/monitored-service/components/ServiceHealth/components/ChangesAndServiceDependency/components/ChangesTable/components/ChangeEventCard/components/EventCards/SRMStepAnalysis/SRMStepAnalysis.constants'
+import { MonitoredServiceConfigurationsTabsEnum } from '@cv/pages/monitored-service/components/Configurations/components/Service/components/CommonMonitoredServiceConfigurations/CommonMonitoredServiceConfigurations.constants'
 
 export enum EVENT_TYPE {
   KNOWN = 'KNOWN',
@@ -232,6 +233,7 @@ export const getEnvironmentOptions = ({
 interface GetCVMonitoringServicesSearchParamProps {
   view?: Views
   tab?: MonitoredServiceEnum
+  subTab?: MonitoredServiceConfigurationsTabsEnum
   redirectToSLO?: boolean
   sloIdentifier?: string
   monitoredServiceIdentifier?: string


### PR DESCRIPTION
### Summary
1. Adding support for Tabs url for monitored service configurations.
2. Redirecting the links of configure health source and notifications in Analyse Deployment Impact step to specific Tabs.
<!-- ✍️ A clear and concise description...-->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
