### PR TITLE
feat: [PL-40569]: new ux for chatbot

### DIFF
--- a/src/modules/10-common/components/DocsChat/DocsChat.module.scss
+++ b/src/modules/10-common/components/DocsChat/DocsChat.module.scss
@@ -12,8 +12,8 @@
   flex-direction: column;
 
   .header {
-    margin: 15px 24px 0px;
-    padding-bottom: 15px;
+    margin: var(--spacing-medium) var(--spacing-large) 0px;
+    padding-bottom: var(--spacing-medium);
     border-bottom: 1px solid var(--grey-200);
   }
 
@@ -32,13 +32,13 @@
   .messagesContainer {
     overflow-y: auto;
     overflow-x: hidden;
-    padding: 0 20px;
+    padding: 0 var(--spacing-large);
     margin-top: auto;
     display: flex;
     flex-direction: column;
 
     .messageContainer {
-      margin: 10px 0;
+      margin: var(--spacing-small) 0;
       display: flex;
       align-items: start;
 
@@ -47,7 +47,7 @@
       }
 
       .message {
-        padding: 10px 24px;
+        padding: var(--spacing-small) var(--spacing-large);
         margin: 0 var(--spacing-small);
         display: inline-block;
         max-width: 75%;
@@ -59,7 +59,7 @@
         }
 
         &.loader {
-          padding: 16px 32px;
+          padding: var(--spacing-medium) var(--spacing-xxlarge);
         }
       }
 
@@ -91,9 +91,9 @@
 
     .input {
       width: 100%;
-      padding: 0 42px;
+      padding: 0 var(--spacing-xxxlarge);
       resize: none;
-      min-height: 42px;
+      min-height: var(--spacing-xxxlarge);
       border: 1px solid var(--grey-200);
     }
 
@@ -102,7 +102,7 @@
       padding: var(--spacing-small);
       background: none;
       position: absolute;
-      right: 8px;
+      right: var(--spacing-small);
       svg > path {
         color: var(--ai-purple-800);
       }
@@ -113,8 +113,8 @@
 .chatMenuButton {
   position: absolute;
   padding: 2px 7px 7px 7px;
-  left: 17px;
-  top: 17px;
+  left: var(--spacing-medium);
+  top: var(--spacing-medium);
   border: none;
   border-radius: 50%;
   background-color: var(--grey-500);

--- a/src/modules/10-common/components/DocsChat/DocsChat.module.scss
+++ b/src/modules/10-common/components/DocsChat/DocsChat.module.scss
@@ -6,18 +6,15 @@
  */
 
 .container {
-  width: 400px;
-  min-height: 300px;
-  max-height: 80vh;
-  display: grid;
-  grid-template-rows: auto 1fr auto;
+  width: 488px;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
 
   .header {
-    background: var(--ai-purple-700);
-    color: var(--white);
-    padding: var(--spacing-small);
-    border-bottom: 1px solid var(--ai-purple-400);
-    text-align: center;
+    margin: 15px 24px 0px;
+    padding-bottom: 15px;
+    border-bottom: 1px solid var(--grey-200);
   }
 
   .errorLink {
@@ -35,104 +32,94 @@
   .messagesContainer {
     overflow-y: auto;
     overflow-x: hidden;
-    padding: 0 var(--spacing-small);
+    padding: 0 20px;
+    margin-top: auto;
+    display: flex;
+    flex-direction: column;
 
     .messageContainer {
-      margin: var(--spacing-medium) 0;
+      margin: 10px 0;
       display: flex;
-      align-items: end;
+      align-items: start;
 
       .aidaIcon {
         z-index: 2;
       }
 
       .message {
-        padding: 10px 20px 0 20px;
-        margin: 0 5px;
+        padding: 10px 24px;
+        margin: 0 var(--spacing-small);
         display: inline-block;
-        max-width: 80%;
-        border-radius: 25px;
-        position: relative;
-        line-height: 21px;
+        max-width: 75%;
         word-wrap: break-word;
+        line-height: 20px;
 
-        &:before,
-        &:after {
-          content: '';
-          position: absolute;
-          bottom: 0;
-          height: 25px;
+        p {
+          margin: 0;
         }
 
-        &.user {
-          background: var(--ai-purple-700);
-          color: var(--white);
-
-          &:before {
-            right: -7px;
-            width: 20px;
-            background-color: var(--ai-purple-700);
-            border-bottom-left-radius: 16px 14px;
-          }
-
-          &:after {
-            right: -26px;
-            width: 26px;
-            background-color: var(--white);
-            border-bottom-left-radius: 10px;
-          }
-        }
-        &.harness {
-          background: var(--ai-purple-200);
-          color: var(--ai-purple-900);
-
-          &:before {
-            left: -7px;
-            width: 20px;
-            background-color: var(--ai-purple-200);
-            border-bottom-right-radius: 16px;
-          }
-
-          &:after {
-            left: -26px;
-            width: 26px;
-            background-color: var(--white);
-            border-bottom-right-radius: 10px;
-          }
-        }
         &.loader {
           padding: 16px 32px;
         }
       }
 
-      &.right {
-        justify-content: right;
-      }
-      &.left {
+      &.harness {
         justify-content: left;
+
+        .message {
+          border-radius: 0px 24px 24px 24px;
+          background: var(--grey-50);
+          border: 4px solid var(--ai-purple-100);
+        }
+      }
+
+      &.user {
+        justify-content: right;
+
+        .message {
+          border-radius: 24px 0px 24px 24px;
+          background: var(--grey-100);
+        }
       }
     }
   }
 
   .inputContainer {
     padding: var(--spacing-small);
+    margin-bottom: var(--spacing-medium);
+    position: relative;
 
     .input {
       width: 100%;
-      padding: 0 15px;
-      border-radius: 25px;
+      padding: 0 42px;
       resize: none;
       min-height: 42px;
-      border: 1px solid var(--grey-500);
+      border: 1px solid var(--grey-200);
     }
 
     .submitButton {
-      border: 1px solid var(--grey-500);
-      color: var(--white);
-      height: 42px;
-      width: 47px;
-      border-radius: 50%;
+      border: none;
+      padding: var(--spacing-small);
+      background: none;
+      position: absolute;
+      right: 8px;
+      svg > path {
+        color: var(--ai-purple-800);
+      }
     }
+  }
+}
+
+.chatMenuButton {
+  position: absolute;
+  padding: 2px 7px 7px 7px;
+  left: 17px;
+  top: 17px;
+  border: none;
+  border-radius: 50%;
+  background-color: var(--grey-500);
+  svg > path {
+    color: var(--white);
   }
 }
 
@@ -141,8 +128,7 @@
   width: 10px;
   height: 10px;
   border-radius: 5px;
-  background-color: var(--white);
-  color: var(--white);
+  background-color: var(--ai-purple-100);
   animation: dotflashing 1s infinite linear alternate;
   animation-delay: 0.5s;
 }
@@ -158,8 +144,7 @@
   width: 10px;
   height: 10px;
   border-radius: 5px;
-  background-color: var(--white);
-  color: var(--white);
+  background-color: var(--ai-purple-100);
   animation: dotflashing 1s infinite alternate;
   animation-delay: 0s;
 }
@@ -168,18 +153,17 @@
   width: 10px;
   height: 10px;
   border-radius: 5px;
-  background-color: var(--white);
-  color: var(--white);
+  background-color: var(--ai-purple-100);
   animation: dotflashing 1s infinite alternate;
   animation-delay: 1s;
 }
 
 @keyframes dotflashing {
   0% {
-    background-color: var(--white);
+    background-color: var(--ai-purple-100);
   }
   50%,
   100% {
-    background-color: rgba(255, 255, 255, 0.4);
+    background-color: var(--ai-purple-600);
   }
 }

--- a/src/modules/10-common/components/DocsChat/DocsChat.module.scss
+++ b/src/modules/10-common/components/DocsChat/DocsChat.module.scss
@@ -20,11 +20,22 @@
     color: var(--ai-purple-900);
   }
 
-  .votedUp svg {
+  .voteButton {
+    border: none;
+    background-color: transparent;
+    padding: var(--spacing-small);
+    cursor: pointer;
+
+    &:hover:enabled {
+      color: var(--primary-7);
+    }
+  }
+
+  .votedUp {
     color: var(--green-800);
   }
 
-  .votedDown svg {
+  .votedDown {
     color: var(--red-800);
   }
 

--- a/src/modules/10-common/components/DocsChat/DocsChat.module.scss
+++ b/src/modules/10-common/components/DocsChat/DocsChat.module.scss
@@ -6,7 +6,6 @@
  */
 
 .container {
-  width: 488px;
   height: 100vh;
   display: flex;
   flex-direction: column;

--- a/src/modules/10-common/components/DocsChat/DocsChat.module.scss
+++ b/src/modules/10-common/components/DocsChat/DocsChat.module.scss
@@ -52,6 +52,7 @@
         max-width: 75%;
         word-wrap: break-word;
         line-height: 20px;
+        overflow-x: auto;
 
         p {
           margin: 0;

--- a/src/modules/10-common/components/DocsChat/DocsChat.module.scss.d.ts
+++ b/src/modules/10-common/components/DocsChat/DocsChat.module.scss.d.ts
@@ -8,6 +8,7 @@
 // this is an auto-generated file, do not update this manually
 declare const styles: {
   readonly aidaIcon: string
+  readonly chatMenuButton: string
   readonly container: string
   readonly dotflashing: string
   readonly errorLink: string
@@ -15,12 +16,10 @@ declare const styles: {
   readonly header: string
   readonly input: string
   readonly inputContainer: string
-  readonly left: string
   readonly loader: string
   readonly message: string
   readonly messageContainer: string
   readonly messagesContainer: string
-  readonly right: string
   readonly submitButton: string
   readonly user: string
   readonly votedDown: string

--- a/src/modules/10-common/components/DocsChat/DocsChat.module.scss.d.ts
+++ b/src/modules/10-common/components/DocsChat/DocsChat.module.scss.d.ts
@@ -22,6 +22,7 @@ declare const styles: {
   readonly messagesContainer: string
   readonly submitButton: string
   readonly user: string
+  readonly voteButton: string
   readonly votedDown: string
   readonly votedUp: string
 }

--- a/src/modules/10-common/components/DocsChat/DocsChat.tsx
+++ b/src/modules/10-common/components/DocsChat/DocsChat.tsx
@@ -265,6 +265,7 @@ function DocsChat(): JSX.Element {
           onChange={handleUserInput}
           onKeyDown={handleKeyDown}
           autoComplete="off"
+          placeholder={getString('common.csBot.placeholder')}
         />
         <button onClick={handleSubmitClick} className={css.submitButton}>
           <Icon name="pipeline-deploy" size={24} />

--- a/src/modules/10-common/components/DocsChat/DocsChat.tsx
+++ b/src/modules/10-common/components/DocsChat/DocsChat.tsx
@@ -7,8 +7,9 @@
 
 import React, { useLayoutEffect, useRef, useState } from 'react'
 import cx from 'classnames'
-import { Avatar, Button, ButtonVariation, Icon, Layout, Popover, Text, useToggleOpen } from '@harness/uicore'
-import { Menu, MenuItem } from '@blueprintjs/core'
+import { Avatar, Button, ButtonVariation, Icon, Layout, Popover, Tag, Text, useToggleOpen } from '@harness/uicore'
+import { Color } from '@harness/design-system'
+import { Intent, Menu, MenuItem } from '@blueprintjs/core'
 import { useTelemetry, useTrackEvent } from '@common/hooks/useTelemetry'
 import { AIChatActions } from '@common/constants/TrackingConstants'
 import { useHarnessSupportBot } from 'services/notifications'
@@ -165,7 +166,7 @@ function DocsChat(): JSX.Element {
 
   useLayoutEffect(() => {
     // scroll to bottom on every message
-    messageList.current?.scrollTo(0, messageList.current?.scrollHeight)
+    messageList.current?.scrollTo?.(0, messageList.current?.scrollHeight)
   }, [messages])
 
   useDeepCompareEffect(() => {
@@ -178,8 +179,9 @@ function DocsChat(): JSX.Element {
   }
 
   const loadingMessage = (
-    <div className={cx(css.messageContainer, css.left)}>
-      <div className={cx(css.message, css.harness, css.loader)}>
+    <div className={cx(css.messageContainer, css.harness)}>
+      <Icon name="harness-copilot" size={30} className={css.aidaIcon} />
+      <div className={cx(css.message, css.loader)}>
         <div className={css.dotflashing}></div>
       </div>
     </div>
@@ -187,43 +189,47 @@ function DocsChat(): JSX.Element {
 
   return (
     <div className={css.container}>
-      <Layout.Horizontal className={css.header} flex>
-        <String stringID="common.csBot.title" />
-        <Popover minimal position="bottom-left">
-          <Button icon="menu" variation={ButtonVariation.ICON} />
-          <Menu>
-            <MenuItem text="Clear History" onClick={clearHistory} />
-          </Menu>
-        </Popover>
-      </Layout.Horizontal>
+      <Layout.Vertical spacing={'small'} className={css.header}>
+        <Layout.Horizontal spacing={'small'} style={{ alignItems: 'center' }}>
+          <Icon name="harness-copilot" size={32} />
+          <Text font={{ size: 'medium', weight: 'bold' }} color={Color.BLACK}>
+            <String stringID="common.csBot.title" />
+          </Text>
+          <Tag intent={Intent.PRIMARY}>
+            <String stringID="common.csBot.beta" />
+          </Tag>
+        </Layout.Horizontal>
+        <Layout.Horizontal spacing={'xsmall'} style={{ alignItems: 'center' }}>
+          <String stringID="common.csBot.subtitle" />
+          <a href="https://developer.harness.io" rel="noreferrer nofollow" target="_blank">
+            <String stringID="common.csBot.hdh" />
+          </a>
+          <Icon name="main-share" size={12} />
+        </Layout.Horizontal>
+      </Layout.Vertical>
       <div className={css.messagesContainer} ref={messageList}>
         {messages.map((message, index) => {
           return (
             <div key={message.text + index}>
               <div
                 className={cx(css.messageContainer, {
-                  [css.left]: message.author === 'harness',
-                  [css.right]: message.author === 'user'
+                  [css.harness]: message.author === 'harness',
+                  [css.user]: message.author === 'user'
                 })}
               >
                 {message.author === 'harness' ? (
                   <Icon name="harness-copilot" size={30} className={css.aidaIcon} />
                 ) : null}
-                <div
-                  className={cx(css.message, {
-                    [css.harness]: message.author === 'harness',
-                    [css.user]: message.author === 'user'
-                  })}
-                >
-                  {message.text === 'error' ? (
-                    <p>
+                <div className={css.message}>
+                  <p>
+                    {message.text === 'error' ? (
                       <a href="javascript:;" onClick={openSubmitTicketModal} className={css.errorLink}>
                         {getString('common.csBot.errorMessage')}
                       </a>
-                    </p>
-                  ) : (
-                    <p>{message.text}</p>
-                  )}
+                    ) : (
+                      message.text
+                    )}
+                  </p>
                 </div>
                 {message.author === 'user' ? (
                   <Avatar size={'small'} name={currentUserInfo.name} email={currentUserInfo.email} hoverCard={false} />
@@ -242,20 +248,27 @@ function DocsChat(): JSX.Element {
         {loading ? loadingMessage : null}
       </div>
       <div className={css.inputContainer}>
-        <Layout.Horizontal spacing="small">
-          <input
-            type="text"
-            name="user-input"
-            className={css.input}
-            value={userInput}
-            onChange={handleUserInput}
-            onKeyDown={handleKeyDown}
-            autoComplete="off"
-          />
-          <button onClick={handleSubmitClick} className={css.submitButton}>
-            <Icon name="key-enter" />
+        <Popover minimal>
+          <button className={css.chatMenuButton}>
+            <Icon name="menu" size={12} />
           </button>
-        </Layout.Horizontal>
+          <Menu>
+            <MenuItem text="Clear History" onClick={clearHistory} />
+          </Menu>
+        </Popover>
+        <input
+          type="text"
+          autoFocus
+          name="user-input"
+          className={css.input}
+          value={userInput}
+          onChange={handleUserInput}
+          onKeyDown={handleKeyDown}
+          autoComplete="off"
+        />
+        <button onClick={handleSubmitClick} className={css.submitButton}>
+          <Icon name="pipeline-deploy" size={24} />
+        </button>
       </div>
       <SubmitTicketModal isOpen={isOpen} close={closeSubmitTicketModal} />
     </div>

--- a/src/modules/10-common/components/DocsChat/DocsChat.tsx
+++ b/src/modules/10-common/components/DocsChat/DocsChat.tsx
@@ -10,6 +10,7 @@ import cx from 'classnames'
 import { Avatar, Button, ButtonVariation, Icon, Layout, Popover, Tag, Text, useToggleOpen } from '@harness/uicore'
 import { Color } from '@harness/design-system'
 import { Intent, Menu, MenuItem } from '@blueprintjs/core'
+import ReactMarkdown from 'react-markdown'
 import { useTelemetry, useTrackEvent } from '@common/hooks/useTelemetry'
 import { AIChatActions } from '@common/constants/TrackingConstants'
 import { useHarnessSupportBot } from 'services/notifications'
@@ -221,15 +222,13 @@ function DocsChat(): JSX.Element {
                   <Icon name="harness-copilot" size={30} className={css.aidaIcon} />
                 ) : null}
                 <div className={css.message}>
-                  <p>
-                    {message.text === 'error' ? (
-                      <a href="javascript:;" onClick={openSubmitTicketModal} className={css.errorLink}>
-                        {getString('common.csBot.errorMessage')}
-                      </a>
-                    ) : (
-                      message.text
-                    )}
-                  </p>
+                  {message.text === 'error' ? (
+                    <a href="javascript:;" onClick={openSubmitTicketModal} className={css.errorLink}>
+                      {getString('common.csBot.errorMessage')}
+                    </a>
+                  ) : (
+                    <ReactMarkdown>{message.text}</ReactMarkdown>
+                  )}
                 </div>
                 {message.author === 'user' ? (
                   <Avatar size={'small'} name={currentUserInfo.name} email={currentUserInfo.email} hoverCard={false} />

--- a/src/modules/10-common/components/DocsChat/DocsChat.tsx
+++ b/src/modules/10-common/components/DocsChat/DocsChat.tsx
@@ -56,7 +56,7 @@ function UsefulOrNot({ query, answer, openSubmitTicketModal }: UsefulOrNotProps)
     <>
       <Layout.Horizontal flex={{ align: 'center-center' }}>
         <Text>
-          <String stringID="common.csBot.feedback" />
+          <String stringID="common.isHelpful" />
         </Text>
         <button
           disabled={voted !== Vote.None}
@@ -66,7 +66,7 @@ function UsefulOrNot({ query, answer, openSubmitTicketModal }: UsefulOrNotProps)
             setVoted(Vote.Up)
           }}
         >
-          <String stringID="common.yes" />
+          <String stringID="yes" />
         </button>
         <button
           disabled={voted !== Vote.None}
@@ -76,7 +76,7 @@ function UsefulOrNot({ query, answer, openSubmitTicketModal }: UsefulOrNotProps)
             setVoted(Vote.Down)
           }}
         >
-          <String stringID="common.no" />
+          <String stringID="no" />
         </button>
       </Layout.Horizontal>
       {voted === Vote.Down ? (

--- a/src/modules/10-common/components/DocsChat/DocsChat.tsx
+++ b/src/modules/10-common/components/DocsChat/DocsChat.tsx
@@ -7,7 +7,7 @@
 
 import React, { useLayoutEffect, useRef, useState } from 'react'
 import cx from 'classnames'
-import { Avatar, Button, ButtonVariation, Icon, Layout, Popover, Tag, Text, useToggleOpen } from '@harness/uicore'
+import { Avatar, Icon, Layout, Popover, Tag, Text, useToggleOpen } from '@harness/uicore'
 import { Color } from '@harness/design-system'
 import { Intent, Menu, MenuItem } from '@blueprintjs/core'
 import ReactMarkdown from 'react-markdown'
@@ -54,36 +54,36 @@ function UsefulOrNot({ query, answer, openSubmitTicketModal }: UsefulOrNotProps)
 
   return (
     <>
-      <Layout.Horizontal spacing={'small'} flex={{ align: 'center-center' }}>
+      <Layout.Horizontal flex={{ align: 'center-center' }}>
         <Text>
           <String stringID="common.csBot.feedback" />
         </Text>
-        <Button
-          icon="main-thumbsup"
+        <button
           disabled={voted !== Vote.None}
-          variation={ButtonVariation.ICON}
-          className={cx({ [css.votedUp]: voted === Vote.Up })}
+          className={cx({ [css.votedUp]: voted === Vote.Up }, css.voteButton)}
           onClick={() => {
             trackEvent(AIChatActions.BotHelpful, { query, answer })
             setVoted(Vote.Up)
           }}
-        />
-        <Button
-          icon="main-thumbsdown"
+        >
+          <String stringID="common.yes" />
+        </button>
+        <button
           disabled={voted !== Vote.None}
-          variation={ButtonVariation.ICON}
-          className={cx({ [css.votedDown]: voted === Vote.Down })}
+          className={cx({ [css.votedDown]: voted === Vote.Down }, css.voteButton)}
           onClick={() => {
             trackEvent(AIChatActions.BotNotHelpful, { query, answer })
             setVoted(Vote.Down)
           }}
-        />
+        >
+          <String stringID="common.no" />
+        </button>
       </Layout.Horizontal>
       {voted === Vote.Down ? (
-        <Layout.Horizontal spacing="small">
+        <Layout.Horizontal spacing="small" flex={{ align: 'center-center' }}>
           <String stringID="common.csBot.ticketOnError" />
           <a href="javascript:;" onClick={openSubmitTicketModal}>
-            Click Here
+            <String stringID="common.clickHere" />
           </a>
         </Layout.Horizontal>
       ) : null}

--- a/src/modules/10-common/components/DocsChat/__tests__/DocsChat.mock.json
+++ b/src/modules/10-common/components/DocsChat/__tests__/DocsChat.mock.json
@@ -1,0 +1,8 @@
+{
+  "status": "SUCCESS",
+  "data": {
+    "response": "I'm sorry, I don't understand what you're asking. Can you please provide more context or a specific question?"
+  },
+  "metaData": null,
+  "correlationId": "ba2862b3-ce30-493a-b44e-553caac3f279"
+}

--- a/src/modules/10-common/components/DocsChat/__tests__/DocsChat.test.tsx
+++ b/src/modules/10-common/components/DocsChat/__tests__/DocsChat.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { TestWrapper, findPopoverContainer } from '@common/utils/testUtils'
+import DocsChat from '../DocsChat'
+import mockResponse from './DocsChat.mock.json'
+import css from '../DocsChat.module.scss'
+
+jest.mock('services/notifications', () => ({
+  useHarnessSupportBot: jest.fn().mockImplementation(() => {
+    return {
+      mutate: () => mockResponse,
+      data: mockResponse,
+      loading: false
+    }
+  })
+}))
+
+jest.mock('@common/components/ResourceCenter/SubmitTicketModal/SubmitTicketModal', () => ({
+  SubmitTicketModal: jest.fn().mockImplementation(() => <div>SubmitTicketModal</div>)
+}))
+
+jest.mock('@common/hooks', () => ({
+  useDeepCompareEffect: jest.fn().mockImplementation(jest.fn()),
+  useLocalStorage: jest.fn().mockImplementation((_key, defaultVal) => [defaultVal, jest.fn()])
+}))
+
+describe('DocsChat', () => {
+  test('should render correctly', async () => {
+    const user = userEvent.setup()
+    const { findByText } = render(
+      <TestWrapper>
+        <DocsChat />
+      </TestWrapper>
+    )
+    expect(findByText('common.csBot.title')).toBeTruthy()
+    expect(findByText('common.csBot.subtitle')).toBeTruthy()
+    const $menuButton = document.querySelector('.' + css.chatMenuButton)
+    expect($menuButton).toBeTruthy()
+    await user.click($menuButton!)
+    const $menu = findPopoverContainer()
+    expect($menu).toBeTruthy()
+    expect(findByText('Clear History')).toBeTruthy()
+  })
+
+  test('should post messages', async () => {
+    const user = userEvent.setup()
+    const { getByPlaceholderText, container } = render(
+      <TestWrapper>
+        <DocsChat />
+      </TestWrapper>
+    )
+    const $input = getByPlaceholderText('common.csBot.placeholder')
+
+    await user.type($input, 'test')
+    expect($input).toHaveValue('test')
+
+    await user.type($input, '{enter}')
+    expect($input).toHaveValue('')
+
+    const messages = container.querySelectorAll('.' + css.messageContainer)
+    expect(messages.length).toBe(3)
+    expect(messages[0].textContent).toBe('Hi, I can search the Harness Docs for you. How can I help you?')
+    expect(messages[1].textContent).toBe('test')
+    expect(messages[2].textContent).toBe(mockResponse.data.response)
+  })
+})

--- a/src/modules/10-common/layouts/DefaultLayout.tsx
+++ b/src/modules/10-common/layouts/DefaultLayout.tsx
@@ -9,8 +9,8 @@ import React, { useEffect } from 'react'
 
 import cx from 'classnames'
 import { Icon } from '@harness/icons'
-import { Popover } from '@harness/uicore'
-import { PopoverInteractionKind } from '@blueprintjs/core'
+import { Button, ButtonVariation, Popover, useToggleOpen } from '@harness/uicore'
+import { PopoverInteractionKind, Position } from '@blueprintjs/core'
 import MainNav from '@common/navigation/MainNav'
 import SideNav from '@common/navigation/SideNav'
 import { useSidebar } from '@common/navigation/SidebarProvider'
@@ -34,6 +34,7 @@ export function DefaultLayout(props: React.PropsWithChildren<unknown>): React.Re
   const { module } = useModuleInfo()
   const { trackPage, identifyUser } = useTelemetry()
   const { currentUserInfo } = useAppStore()
+  const { isOpen, open, close } = useToggleOpen(false)
   const chatEnabled = useFeatureFlag(FeatureFlag.PL_AI_SUPPORT_CHATBOT)
 
   useEffect(() => {
@@ -67,13 +68,39 @@ export function DefaultLayout(props: React.PropsWithChildren<unknown>): React.Re
       </div>
 
       {chatEnabled ? (
-        <div className={css.chatWrapper}>
-          <Popover interactionKind={PopoverInteractionKind.CLICK}>
-            <div className={css.chatButton}>
-              <Icon name="code-chat" size={24} /> <String stringID="common.csBot.askAIDA" />
-            </div>
-            <DocsChat />
-          </Popover>
+        <div className={css.aux}>
+          <ul className={css.list}>
+            <li>
+              <Popover
+                isOpen={isOpen}
+                minimal
+                position={Position.LEFT_BOTTOM}
+                popoverClassName={css.chatPopover}
+                hasBackdrop
+                interactionKind={PopoverInteractionKind.CLICK}
+                onInteraction={nextOpenState => {
+                  if (!nextOpenState) close()
+                }}
+              >
+                <button className={cx(css.listItem, css.copilot, { [css.open]: isOpen })} onClick={open}>
+                  <Icon name="harness-copilot" size={24} />
+                  <String stringID="common.csBot.aida" className={css.label} />
+                </button>
+                <>
+                  <Button
+                    icon="cross"
+                    iconProps={{
+                      size: 24
+                    }}
+                    variation={ButtonVariation.PRIMARY}
+                    onClick={close}
+                    className={css.closeChat}
+                  />
+                  <DocsChat />
+                </>
+              </Popover>
+            </li>
+          </ul>
         </div>
       ) : null}
     </div>

--- a/src/modules/10-common/layouts/DefaultLayout.tsx
+++ b/src/modules/10-common/layouts/DefaultLayout.tsx
@@ -71,7 +71,13 @@ export function DefaultLayout(props: React.PropsWithChildren<unknown>): React.Re
         <div className={css.aux}>
           <ul className={css.list}>
             <li>
-              <Drawer isOpen={isOpen} onClose={close} size={488}>
+              <Drawer
+                isOpen={isOpen}
+                onClose={close}
+                size={488}
+                style={{ marginRight: '60px' }}
+                transitionDuration={100}
+              >
                 <>
                   <Button
                     icon="cross"

--- a/src/modules/10-common/layouts/DefaultLayout.tsx
+++ b/src/modules/10-common/layouts/DefaultLayout.tsx
@@ -9,8 +9,8 @@ import React, { useEffect } from 'react'
 
 import cx from 'classnames'
 import { Icon } from '@harness/icons'
-import { Button, ButtonVariation, Popover, useToggleOpen } from '@harness/uicore'
-import { PopoverInteractionKind, Position } from '@blueprintjs/core'
+import { Button, ButtonVariation, useToggleOpen } from '@harness/uicore'
+import { Drawer } from '@blueprintjs/core'
 import MainNav from '@common/navigation/MainNav'
 import SideNav from '@common/navigation/SideNav'
 import { useSidebar } from '@common/navigation/SidebarProvider'
@@ -71,21 +71,7 @@ export function DefaultLayout(props: React.PropsWithChildren<unknown>): React.Re
         <div className={css.aux}>
           <ul className={css.list}>
             <li>
-              <Popover
-                isOpen={isOpen}
-                minimal
-                position={Position.LEFT_BOTTOM}
-                popoverClassName={css.chatPopover}
-                hasBackdrop
-                interactionKind={PopoverInteractionKind.CLICK}
-                onInteraction={nextOpenState => {
-                  if (!nextOpenState) close()
-                }}
-              >
-                <button className={cx(css.listItem, css.copilot, { [css.open]: isOpen })} onClick={open}>
-                  <Icon name="harness-copilot" size={24} />
-                  <String stringID="common.csBot.aida" className={css.label} />
-                </button>
+              <Drawer isOpen={isOpen} onClose={close} size={488}>
                 <>
                   <Button
                     icon="cross"
@@ -98,7 +84,11 @@ export function DefaultLayout(props: React.PropsWithChildren<unknown>): React.Re
                   />
                   <DocsChat />
                 </>
-              </Popover>
+              </Drawer>
+              <button className={cx(css.listItem, css.copilot, { [css.open]: isOpen })} onClick={open}>
+                <Icon name="harness-copilot" size={24} />
+                <String stringID="common.csBot.aida" className={css.label} />
+              </button>
             </li>
           </ul>
         </div>

--- a/src/modules/10-common/layouts/layouts.module.scss
+++ b/src/modules/10-common/layouts/layouts.module.scss
@@ -61,6 +61,61 @@
   }
 }
 
+.aux {
+  width: 66px;
+  padding: 24px 0;
+  background: var(--white);
+  border-left: 1px solid var(--grey-200);
+  display: flex;
+  flex-direction: column-reverse;
+  align-items: center;
+  height: 100vh;
+  position: sticky;
+  bottom: 0;
+  align-self: flex-end;
+
+  .list {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+
+    .listItem {
+      border: none;
+      height: 48px;
+      padding: 0 20px;
+      background: none;
+      cursor: pointer;
+
+      .label {
+        font-size: 9px;
+        line-height: 15px;
+      }
+    }
+
+    .copilot {
+      &:hover,
+      &.open {
+        background-color: var(--ai-purple-800);
+        color: var(--white);
+        svg > path {
+          fill: var(--white) !important;
+        }
+      }
+    }
+  }
+}
+
+.chatPopover {
+  box-shadow: 0.5px -1px 16px 0px rgba(0, 0, 0, 0.08) !important;
+}
+.closeChat {
+  position: absolute;
+  left: -40px;
+  height: 40px !important;
+  width: 40px !important;
+  padding-left: 20px !important;
+}
+
 :global {
   .PageBody--pageBody {
     height: unset !important;

--- a/src/modules/10-common/layouts/layouts.module.scss
+++ b/src/modules/10-common/layouts/layouts.module.scss
@@ -105,9 +105,6 @@
   }
 }
 
-.chatPopover {
-  box-shadow: 0.5px -1px 16px 0px rgba(0, 0, 0, 0.08) !important;
-}
 .closeChat {
   position: absolute;
   left: -40px;

--- a/src/modules/10-common/layouts/layouts.module.scss
+++ b/src/modules/10-common/layouts/layouts.module.scss
@@ -162,25 +162,3 @@
 .btn {
   margin-top: 1px !important;
 }
-
-.chatWrapper {
-  position: fixed;
-  bottom: 24px;
-  right: 24px;
-  z-index: 10;
-}
-
-.chatButton {
-  background-color: var(--ai-purple-900);
-  padding: 10px;
-  border-radius: 10px;
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-  color: var(--white);
-  box-shadow: 1px 2px 5px 0px rgba(0, 0, 0, 0.3);
-
-  path {
-    stroke: var(--white);
-  }
-}

--- a/src/modules/10-common/layouts/layouts.module.scss.d.ts
+++ b/src/modules/10-common/layouts/layouts.module.scss.d.ts
@@ -9,8 +9,6 @@
 declare const styles: {
   readonly aux: string
   readonly btn: string
-  readonly chatButton: string
-  readonly chatWrapper: string
   readonly children: string
   readonly closeChat: string
   readonly copilot: string

--- a/src/modules/10-common/layouts/layouts.module.scss.d.ts
+++ b/src/modules/10-common/layouts/layouts.module.scss.d.ts
@@ -10,7 +10,6 @@ declare const styles: {
   readonly aux: string
   readonly btn: string
   readonly chatButton: string
-  readonly chatPopover: string
   readonly chatWrapper: string
   readonly children: string
   readonly closeChat: string

--- a/src/modules/10-common/layouts/layouts.module.scss.d.ts
+++ b/src/modules/10-common/layouts/layouts.module.scss.d.ts
@@ -7,20 +7,28 @@
  **/
 // this is an auto-generated file, do not update this manually
 declare const styles: {
+  readonly aux: string
   readonly btn: string
   readonly chatButton: string
+  readonly chatPopover: string
   readonly chatWrapper: string
   readonly children: string
+  readonly closeChat: string
+  readonly copilot: string
   readonly expired: string
   readonly featuresBanner: string
   readonly flex: string
   readonly info: string
   readonly infoIcon: string
   readonly issueIcon: string
+  readonly label: string
   readonly levelUp: string
   readonly link: string
+  readonly list: string
+  readonly listItem: string
   readonly main: string
   readonly notExpired: string
+  readonly open: string
   readonly overUse: string
   readonly rhs: string
   readonly trialLicenseBanner: string

--- a/src/modules/10-common/strings/strings.en.yaml
+++ b/src/modules/10-common/strings/strings.en.yaml
@@ -1579,6 +1579,7 @@ csBot:
   askAIDA: Ask AIDA
   title: Harness AIDA Chatbot
   beta: BETA
+  placeholder: How do I install a delegate?
   subtitle: I can help searching anything on
   hdh: Harness Developer Hub
   feedback: Was this answer helpful?

--- a/src/modules/10-common/strings/strings.en.yaml
+++ b/src/modules/10-common/strings/strings.en.yaml
@@ -1575,8 +1575,12 @@ favorite:
   add: Add to Favorites
   remove: Remove from Favorites
 csBot:
+  aida: AIDA
   askAIDA: Ask AIDA
-  title: Harness AIDA Chat
+  title: Harness AIDA Chatbot
+  beta: BETA
+  subtitle: I can help searching anything on
+  hdh: Harness Developer Hub
   feedback: Was this answer helpful?
   errorMessage: Something went wrong. Click here to submit a ticket instead.
   ticketOnError: Would you like to create a support ticket?

--- a/src/modules/10-common/strings/strings.en.yaml
+++ b/src/modules/10-common/strings/strings.en.yaml
@@ -1574,8 +1574,6 @@ category: Category
 favorite:
   add: Add to Favorites
   remove: Remove from Favorites
-yes: Yes
-no: No
 clickHere: Click Here
 csBot:
   aida: AIDA
@@ -1585,7 +1583,6 @@ csBot:
   placeholder: How do I install a delegate?
   subtitle: I can help searching anything on
   hdh: Harness Developer Hub
-  feedback: Helpful?
   errorMessage: Something went wrong. Click here to submit a ticket instead.
   ticketOnError: Would you like to create a support ticket?
 addNewCreditCard: Add a new card

--- a/src/modules/10-common/strings/strings.en.yaml
+++ b/src/modules/10-common/strings/strings.en.yaml
@@ -1574,6 +1574,9 @@ category: Category
 favorite:
   add: Add to Favorites
   remove: Remove from Favorites
+yes: Yes
+no: No
+clickHere: Click Here
 csBot:
   aida: AIDA
   askAIDA: Ask AIDA
@@ -1582,7 +1585,7 @@ csBot:
   placeholder: How do I install a delegate?
   subtitle: I can help searching anything on
   hdh: Harness Developer Hub
-  feedback: Was this answer helpful?
+  feedback: Helpful?
   errorMessage: Something went wrong. Click here to submit a ticket instead.
   ticketOnError: Would you like to create a support ticket?
 addNewCreditCard: Add a new card

--- a/src/modules/27-platform/connectors/pages/connectors/views/ConnectorsListView.module.scss
+++ b/src/modules/27-platform/connectors/pages/connectors/views/ConnectorsListView.module.scss
@@ -6,7 +6,6 @@
  */
 
 .table {
-  width: calc(100vw - 270px);
   min-width: 1300px;
   padding: var(--spacing-small) var(--spacing-xlarge);
 

--- a/src/modules/70-pipeline/pages/pipeline-details/PipelineDetails.tsx
+++ b/src/modules/70-pipeline/pages/pipeline-details/PipelineDetails.tsx
@@ -26,7 +26,7 @@ import { useStrings, String } from 'framework/strings'
 import { useAppStore } from 'framework/AppStore/AppStoreContext'
 import { GitSyncStoreProvider } from 'framework/GitRepoStore/GitSyncStoreContext'
 import type { GitQueryParams, PipelinePathProps, PipelineType } from '@common/interfaces/RouteInterfaces'
-import { useFeatureFlags } from '@common/hooks/useFeatureFlag'
+import { useFeatureFlag, useFeatureFlags } from '@common/hooks/useFeatureFlag'
 import { DefaultNewPipelineId } from '@pipeline/components/PipelineStudio/PipelineContext/PipelineActions'
 import GitPopover from '@pipeline/components/GitPopover/GitPopover'
 import GenericErrorHandler from '@common/pages/GenericErrorHandler/GenericErrorHandler'
@@ -36,6 +36,7 @@ import { StoreType } from '@common/constants/GitSyncTypes'
 import type { GitFilterScope } from '@common/components/GitFilters/GitFilters'
 import { BannerEOL } from '@pipeline/components/BannerEOL/BannerEOL'
 import { isSimplifiedYAMLEnabled } from '@common/utils/utils'
+import { FeatureFlag } from '@common/featureFlags'
 import NoEntityFound from '../utils/NoEntityFound/NoEntityFound'
 import css from './PipelineDetails.module.scss'
 
@@ -121,6 +122,7 @@ function PipelinePage({ children }: React.PropsWithChildren<unknown>): React.Rea
   const [triggerTabDisabled, setTriggerTabDisabled] = React.useState(false)
   const [showBanner, setShowBanner] = React.useState<boolean>(false)
   const { CI_YAML_VERSIONING, CDS_V1_EOL_BANNER } = useFeatureFlags()
+  const auxNavEnabled = useFeatureFlag(FeatureFlag.PL_AI_SUPPORT_CHATBOT)
   const isYAMLSimplicationEnabledForCI = isSimplifiedYAMLEnabled(module, CI_YAML_VERSIONING)
 
   const routeParams = {
@@ -276,7 +278,7 @@ function PipelinePage({ children }: React.PropsWithChildren<unknown>): React.Rea
     <>
       <BannerEOL isVisible={showBanner} />
       <Page.Header
-        className={isPipelineStudioV0Route ? css.rightMargin : ''}
+        className={isPipelineStudioV0Route && !auxNavEnabled ? css.rightMargin : ''}
         testId={isPipelineStudioRoute ? 'pipeline-studio' : 'not-pipeline-studio'}
         size={isPipelineStudioRoute ? 'small' : 'standard'}
         title={
@@ -398,7 +400,7 @@ function PipelinePage({ children }: React.PropsWithChildren<unknown>): React.Rea
           />
         }
       />
-      <Page.Body className={isPipelineStudioV0Route ? css.rightMargin : ''}>{children}</Page.Body>
+      <Page.Body className={isPipelineStudioV0Route && !auxNavEnabled ? css.rightMargin : ''}>{children}</Page.Body>
     </>
   )
 }

--- a/src/modules/72-templates-library/components/TemplateStudio/TemplateStudioInternal.tsx
+++ b/src/modules/72-templates-library/components/TemplateStudio/TemplateStudioInternal.tsx
@@ -53,11 +53,12 @@ import { OutOfSyncErrorStrip } from '@pipeline/components/TemplateLibraryErrorHa
 import { TemplateErrorEntity } from '@pipeline/components/TemplateLibraryErrorHandling/utils'
 import { BannerEOL } from '@pipeline/components/BannerEOL/BannerEOL'
 import { yamlStringify } from '@common/utils/YamlHelperMethods'
-import { useFeatureFlags } from '@common/hooks/useFeatureFlag'
+import { useFeatureFlag, useFeatureFlags } from '@common/hooks/useFeatureFlag'
 import { ErrorNodeSummary, useValidateTemplateInputs } from 'services/template-ng'
 import { useCheckIfTemplateUsingV1Stage, ResponseEOLBannerResponseDTO } from 'services/cd-ng'
 import { DefaultNewVersionLabel } from 'framework/Templates/templates'
 import { NodeMetadataProvider } from '@pipeline/components/PipelineDiagram/Nodes/NodeMetadataContext'
+import { FeatureFlag } from '@common/featureFlags'
 import { TemplateContext } from './TemplateContext/TemplateContext'
 import { getContentAndTitleStringKeys, isValidYaml, isPipelineOrStageType, isNewTemplate } from './TemplateStudioUtils'
 import css from './TemplateStudio.module.scss'
@@ -107,6 +108,7 @@ export function TemplateStudioInternal(): React.ReactElement {
   const templateStudioSubHeaderHandleRef = React.useRef<TemplateStudioSubHeaderHandle | null>(null)
   const [shouldShowOutOfSyncError, setShouldShowOutOfSyncError] = React.useState(false)
   const [showBanner, setShowBanner] = React.useState<boolean>(false)
+  const auxNavEnabled = useFeatureFlag(FeatureFlag.PL_AI_SUPPORT_CHATBOT)
 
   const { CDS_V1_EOL_BANNER } = useFeatureFlags()
 
@@ -436,11 +438,11 @@ export function TemplateStudioInternal(): React.ReactElement {
       />
       <BannerEOL isVisible={showBanner} />
       <Page.Header
-        className={css.rightMargin}
+        className={classNames({ [css.rightMargin]: !auxNavEnabled })}
         size={'small'}
         title={<TemplateStudioHeader templateType={templateType as TemplateType} />}
       />
-      <Page.Body className={classNames(css.rightMargin, css.studioWrapper)}>
+      <Page.Body className={classNames({ [css.rightMargin]: !auxNavEnabled }, css.studioWrapper)}>
         {isLoading ? (
           <PageSpinner />
         ) : (

--- a/src/stringTypes.ts
+++ b/src/stringTypes.ts
@@ -235,9 +235,13 @@ export interface StringsMap {
   'common.createFlag': string
   'common.createPipeline': string
   'common.creating': string
+  'common.csBot.aida': string
   'common.csBot.askAIDA': string
+  'common.csBot.beta': string
   'common.csBot.errorMessage': string
   'common.csBot.feedback': string
+  'common.csBot.hdh': string
+  'common.csBot.subtitle': string
   'common.csBot.ticketOnError': string
   'common.csBot.title': string
   'common.current': string

--- a/src/stringTypes.ts
+++ b/src/stringTypes.ts
@@ -241,6 +241,7 @@ export interface StringsMap {
   'common.csBot.errorMessage': string
   'common.csBot.feedback': string
   'common.csBot.hdh': string
+  'common.csBot.placeholder': string
   'common.csBot.subtitle': string
   'common.csBot.ticketOnError': string
   'common.csBot.title': string

--- a/src/stringTypes.ts
+++ b/src/stringTypes.ts
@@ -240,7 +240,6 @@ export interface StringsMap {
   'common.csBot.askAIDA': string
   'common.csBot.beta': string
   'common.csBot.errorMessage': string
-  'common.csBot.feedback': string
   'common.csBot.hdh': string
   'common.csBot.placeholder': string
   'common.csBot.subtitle': string
@@ -713,7 +712,6 @@ export interface StringsMap {
   'common.newVersion': string
   'common.nextExpiringDate': string
   'common.nextStep': string
-  'common.no': string
   'common.noAPIKeys': string
   'common.noActiveDeveloperData': string
   'common.noActiveServiceData': string
@@ -1439,7 +1437,6 @@ export interface StringsMap {
   'common.yamlDiffView.refreshedYamlLabel': string
   'common.yearly': string
   'common.yearlyPeak': string
-  'common.yes': string
   'common.zipCode': string
   'rbac.UserGroupRoleAssignmentForm.assignmentValidation': string
   'rbac.accessControlTitle.resourceGroups': string

--- a/src/stringTypes.ts
+++ b/src/stringTypes.ts
@@ -167,6 +167,7 @@ export interface StringsMap {
   'common.city': string
   'common.clear': string
   'common.clearSelection': string
+  'common.clickHere': string
   'common.clickToExpand': string
   'common.clickToKnowMore': string
   'common.clientId': string
@@ -712,6 +713,7 @@ export interface StringsMap {
   'common.newVersion': string
   'common.nextExpiringDate': string
   'common.nextStep': string
+  'common.no': string
   'common.noAPIKeys': string
   'common.noActiveDeveloperData': string
   'common.noActiveServiceData': string
@@ -1437,6 +1439,7 @@ export interface StringsMap {
   'common.yamlDiffView.refreshedYamlLabel': string
   'common.yearly': string
   'common.yearlyPeak': string
+  'common.yes': string
   'common.zipCode': string
   'rbac.UserGroupRoleAssignmentForm.assignmentValidation': string
   'rbac.accessControlTitle.resourceGroups': string


### PR DESCRIPTION
### Summary

UX changes for the chat bot

#### Screenshots

Adds new aux nav on the right, only to the default layout:
<img width="1728" alt="Screenshot 2023-08-07 at 9 53 45 PM" src="https://github.com/harness/harness-core-ui/assets/47316575/dcdb85d9-f9a9-4202-aaf9-ab6866e85f0d">

<img width="553" alt="Screenshot 2023-08-07 at 9 54 42 PM" src="https://github.com/harness/harness-core-ui/assets/47316575/2fa915ec-2173-40a5-aeb8-035f0486d37e">

<img width="596" alt="Screenshot 2023-08-07 at 9 53 33 PM" src="https://github.com/harness/harness-core-ui/assets/47316575/3d44b5d7-99f1-4bcd-87a3-88823bbcf3c5">

With markdown answers:
<img width="475" alt="Screenshot 2023-08-08 at 8 57 36 PM" src="https://github.com/harness/harness-core-ui/assets/47316575/20e20063-e693-45f2-bedf-73824116a2ad">


#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
