### PR TITLE
fix: [CDS-76431]: `add-your-stage` form is overflowing when adding a parallel stages

### DIFF
--- a/src/modules/70-pipeline/components/PipelineStudio/StageBuilder/StageBuilder.module.scss
+++ b/src/modules/70-pipeline/components/PipelineStudio/StageBuilder/StageBuilder.module.scss
@@ -37,7 +37,7 @@ $dot-space: 10px;
     width: 100%;
     position: relative;
     border-top: 2px solid var(--grey-100);
-    overflow: scroll;
+    overflow: auto;
     background: linear-gradient(90deg, $bg-color ($dot-space - $dot-size), transparent 1%) center,
       linear-gradient($bg-color ($dot-space - $dot-size), transparent 1%) center, $dot-color;
     background-size: $dot-space $dot-space;

--- a/src/modules/70-pipeline/components/PipelineStudio/StageBuilder/StageBuilder.module.scss
+++ b/src/modules/70-pipeline/components/PipelineStudio/StageBuilder/StageBuilder.module.scss
@@ -37,7 +37,7 @@ $dot-space: 10px;
     width: 100%;
     position: relative;
     border-top: 2px solid var(--grey-100);
-
+    overflow: scroll;
     background: linear-gradient(90deg, $bg-color ($dot-space - $dot-size), transparent 1%) center,
       linear-gradient($bg-color ($dot-space - $dot-size), transparent 1%) center, $dot-color;
     background-size: $dot-space $dot-space;

--- a/src/modules/75-cd/components/PipelineSteps/DeployServiceEntityStep/__tests__/__snapshots__/DeployServiceEntityWidget.SingleService.test.tsx.snap
+++ b/src/modules/75-cd/components/PipelineSteps/DeployServiceEntityStep/__tests__/__snapshots__/DeployServiceEntityWidget.SingleService.test.tsx.snap
@@ -1556,7 +1556,7 @@ exports[`DeployServiceEntityWidget - single service tests user can edit selected
                       class="Layout--vertical StyledProps--main StyledProps--padding-right-huge"
                     >
                       <div
-                        class="Layout--horizontal Layout--layout-spacing-medium StyledProps--main cardListContainer"
+                        class="Layout--horizontal StyledProps--main cardListContainer"
                       >
                         <label
                           class="Thumbnail--squareCardContainer"

--- a/src/modules/75-cd/components/PipelineStudio/DeployServiceSpecifications/DeployServiceDefinition/__tests__/__snapshots__/DeployServiceDefinition.test.tsx.snap
+++ b/src/modules/75-cd/components/PipelineStudio/DeployServiceSpecifications/DeployServiceDefinition/__tests__/__snapshots__/DeployServiceDefinition.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`DeployServiceDefinition Changing the deployment type when the stage con
           class="Layout--vertical StyledProps--main StyledProps--padding-right-huge"
         >
           <div
-            class="Layout--horizontal Layout--layout-spacing-medium StyledProps--main cardListContainer"
+            class="Layout--horizontal StyledProps--main cardListContainer"
           >
             <label
               class="Thumbnail--squareCardContainer"
@@ -452,7 +452,7 @@ exports[`DeployServiceDefinition checking on the gitops with other stage data sh
           class="Layout--vertical StyledProps--main StyledProps--padding-right-huge"
         >
           <div
-            class="Layout--horizontal Layout--layout-spacing-medium StyledProps--main cardListContainer"
+            class="Layout--horizontal StyledProps--main cardListContainer"
           >
             <label
               class="Thumbnail--squareCardContainer"
@@ -877,7 +877,7 @@ exports[`DeployServiceDefinition should render DeployServiceDefinition and switc
           class="Layout--vertical StyledProps--main StyledProps--padding-right-huge"
         >
           <div
-            class="Layout--horizontal Layout--layout-spacing-medium StyledProps--main cardListContainer"
+            class="Layout--horizontal StyledProps--main cardListContainer"
           >
             <label
               class="Thumbnail--squareCardContainer"

--- a/src/modules/75-cd/components/PipelineStudio/DeployServiceSpecifications/SelectDeploymentType/SelectDeploymentType.tsx
+++ b/src/modules/75-cd/components/PipelineStudio/DeployServiceSpecifications/SelectDeploymentType/SelectDeploymentType.tsx
@@ -202,7 +202,7 @@ const CardList = ({ items, isReadonly, selectedValue, onChange }: CardListProps)
     onChange(e.target.value as ServiceDeploymentType)
   }
   return (
-    <Layout.Horizontal spacing={'medium'} className={stageCss.cardListContainer}>
+    <Layout.Horizontal className={stageCss.cardListContainer}>
       {items
         .filter(item => (isReadonly && item.value === selectedValue) || !isReadonly)
         .map(item => {

--- a/src/modules/75-cd/components/PipelineStudio/DeployStageSetupShell/DeployStage.module.scss
+++ b/src/modules/75-cd/components/PipelineStudio/DeployStageSetupShell/DeployStage.module.scss
@@ -17,6 +17,7 @@
 
 .deployStage {
   min-width: 464px;
+  max-width: 864px;
   height: 635px;
   margin-top: 2px;
   overflow-y: scroll;
@@ -108,6 +109,9 @@
   }
   .cardListContainer {
     margin-top: 0 !important;
+    gap: var(--spacing-medium);
+    flex-wrap: wrap;
+    margin-left: 0 !important;
   }
 }
 

--- a/src/modules/75-cd/components/PipelineStudio/DeployStageSetupShell/DeployStage.module.scss
+++ b/src/modules/75-cd/components/PipelineStudio/DeployStageSetupShell/DeployStage.module.scss
@@ -17,7 +17,7 @@
 
 .deployStage {
   min-width: 464px;
-  max-height: 635px;
+  height: 635px;
   margin-top: 2px;
   overflow-y: scroll;
   .content-section {

--- a/src/modules/75-cd/components/PipelineStudio/DeployStageSetupShell/__tests__/__snapshots__/DeployStageSetupShell.test.tsx.snap
+++ b/src/modules/75-cd/components/PipelineStudio/DeployStageSetupShell/__tests__/__snapshots__/DeployStageSetupShell.test.tsx.snap
@@ -475,7 +475,7 @@ exports[`DeployStageSetupShell tests opens services tab by default 1`] = `
                     class="Layout--vertical StyledProps--main StyledProps--padding-right-huge"
                   >
                     <div
-                      class="Layout--horizontal Layout--layout-spacing-medium StyledProps--main cardListContainer"
+                      class="Layout--horizontal StyledProps--main cardListContainer"
                     >
                       <label
                         class="Thumbnail--squareCardContainer"

--- a/src/modules/75-cd/components/Services/ServiceStudio/ServiceConfiguration/__tests__/__snapshots__/ServiceConfiguration.test.tsx.snap
+++ b/src/modules/75-cd/components/Services/ServiceStudio/ServiceConfiguration/__tests__/__snapshots__/ServiceConfiguration.test.tsx.snap
@@ -306,7 +306,7 @@ exports[`Service Configuration renders correctly 1`] = `
               class="Layout--vertical StyledProps--main StyledProps--padding-right-huge"
             >
               <div
-                class="Layout--horizontal Layout--layout-spacing-medium StyledProps--main cardListContainer"
+                class="Layout--horizontal StyledProps--main cardListContainer"
               >
                 <label
                   class="Thumbnail--squareCardContainer"

--- a/src/modules/75-cd/components/Services/ServiceStudio/__tests__/__snapshots__/ServiceStudioDetails.test.tsx.snap
+++ b/src/modules/75-cd/components/Services/ServiceStudio/__tests__/__snapshots__/ServiceStudioDetails.test.tsx.snap
@@ -237,7 +237,7 @@ exports[`ServiceStudioDetails Service Entity Modal View check 1`] = `
                 class="Layout--vertical StyledProps--main StyledProps--padding-right-huge"
               >
                 <div
-                  class="Layout--horizontal Layout--layout-spacing-medium StyledProps--main cardListContainer"
+                  class="Layout--horizontal StyledProps--main cardListContainer"
                 >
                   <label
                     class="Thumbnail--squareCardContainer"
@@ -655,7 +655,7 @@ exports[`ServiceStudioDetails discard button functionality after update event 1`
                     class="Layout--vertical StyledProps--main StyledProps--padding-right-huge"
                   >
                     <div
-                      class="Layout--horizontal Layout--layout-spacing-medium StyledProps--main cardListContainer"
+                      class="Layout--horizontal StyledProps--main cardListContainer"
                     >
                       <label
                         class="Thumbnail--squareCardContainer"
@@ -1578,7 +1578,7 @@ exports[`ServiceStudioDetails save and publish functionality 1`] = `
                     class="Layout--vertical StyledProps--main StyledProps--padding-right-huge"
                   >
                     <div
-                      class="Layout--horizontal Layout--layout-spacing-medium StyledProps--main cardListContainer"
+                      class="Layout--horizontal StyledProps--main cardListContainer"
                     >
                       <label
                         class="Thumbnail--squareCardContainer"


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->

- fixed height addresses the issue as popover knows while rendering to reposition itself due to lack of space.
- flex-wrap the deployment types in popover
- made stage builder scrollable to accomodate small screen size

#### Screenshots



https://github.com/harness/harness-core-ui/assets/62999423/8ba8fe58-040d-4950-aea0-2f70b7274522





<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### PR Checklist

<details>
<summary>Please check if your PR fulfils the following requirements</summary>

- [ ] Tests for the changes have been added. Ideally, include a test that fails without this PR but passes with it.
- [ ] Docs have been [added/updated](https://harness.atlassian.net/jira/software/c/projects/DOC/boards/40).
</details>

<details>
<summary>Use the following comments to re-trigger PR Checks</summary>

- Jest: `retrigger jest`
- Prettier: `retrigger prettier`
- Type Check: `retrigger typecheck`
- ESLint: `retrigger eslint`
- Sonar: `retrigger sonar`
- Standards: `retrigger standards`
- Build: `retrigger build`
- Title Check: `retrigger titlecheck`
- Feature Name Check: `trigger featurenamecheck`
- Coverage: `retrigger coverage`
- Rebase: `trigger rebase`
- Cypress Rest: `retrigger cypress-rest`
- Cypress CD: `retrigger cypress-cd`
- Cypress Pipeline: `retrigger cypress-pipeline`
- Cypress CV: `retrigger cypress-cv`
- Fix Prettier: `fix prettier`
</details>

#### [Contributor license agreement](https://github.com/harness/harness-core-ui/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
